### PR TITLE
Add support for preserving additional keys in macro of to label value

### DIFF
--- a/src/Macros/CollectionMacro.php
+++ b/src/Macros/CollectionMacro.php
@@ -53,8 +53,19 @@ class CollectionMacro
         );
         Collection::macro(
             'toValueLabelFromObject',
-            function (string $label, string $value, string $labelKey = 'label', string $valueKey = 'value'): Collection {
+            function (
+                string $label,
+                string $value,
+                string $labelKey = 'label',
+                string $valueKey = 'value',
+                array $keysToPreserve = [],
+            ): Collection {
                 return $this->map(fn (object $item) => [
+                    ...collect($keysToPreserve)
+                        ->mapWithKeys(fn (string $key, mixed $index) => [
+                            is_string($index) && ! is_numeric($index) ? $index : $key => $item->{$key},
+                        ])
+                        ->toArray(),
                     $valueKey => $item->{$value},
                     $labelKey => $item->{$label},
                 ]);

--- a/tests/Macros/CollectionTest.php
+++ b/tests/Macros/CollectionTest.php
@@ -61,3 +61,25 @@ it('test value label', function () {
         ->toBeArray()
         ->toHaveKeys(['foo', 'bar']);
 });
+
+it('test value label with keys to preserve', function () {
+    $collection = collect([
+        new FakeModel(['id' => 1, 'name' => 'João', 'optional' => 'optional1']),
+        new FakeModel(['id' => 2, 'name' => 'Paulo', 'optional' => 'optional2']),
+        new FakeModel(['id' => 3, 'name' => 'Lucas', 'optional' => 'optional3']),
+        new FakeModel(['id' => 4, 'name' => 'Fabio', 'optional' => 'optional4']),
+        new FakeModel(['id' => 5, 'name' => 'Carlos', 'optional' => 'optional5']),
+    ]);
+    expect($collection->toValueLabelFromObject('name', 'id', keysToPreserve: ['optional']))
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(5)
+        ->each
+        ->toBeArray()
+        ->toHaveKeys(['label', 'value', 'optional'])
+        ->and($collection->toValueLabelFromObject('name', 'id', 'foo', 'bar', keysToPreserve: ['abc' => 'optional']))
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(5)
+        ->each
+        ->toBeArray()
+        ->toHaveKeys(['foo', 'bar', 'abc']);
+});

--- a/tests/Macros/FakeModel.php
+++ b/tests/Macros/FakeModel.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * @property int $id
  * @property string $name
+ * @property string $optional
  */
 class FakeModel extends Model
 {
@@ -18,5 +19,6 @@ class FakeModel extends Model
     protected $fillable = [
         'id',
         'name',
+        'optional',
     ];
 }


### PR DESCRIPTION
Updated `toValueLabelFromObject` to allow preserving specific keys from the objects in a collection. Added tests to validate the behavior, and extended the `FakeModel` to include a new property for testing purposes.