### PR TITLE
Add NumberMacro for currency spelling support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "require": {
         "php": "^8.3",
         "ext-dom": "*",
+        "ext-intl": "*",
         "inertiajs/inertia-laravel": "^v1.3.0|^2.x-dev",
         "jaybizzle/crawler-detect": "^v1.2.120",
         "spatie/laravel-package-tools": "^1.16.5",
         "illuminate/contracts": "^11.24"
     },
     "require-dev": {
-        "ext-intl": "*",
         "laravel/pint": "^v1.18.1",
         "nunomaduro/collision": "^v8.4.0",
         "orchestra/testbench": "^9.5.0",

--- a/resources/lang/en/number.php
+++ b/resources/lang/en/number.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | LaravelToolkit Language Lines
+    |--------------------------------------------------------------------------
+    |
+    */
+
+    'and' => 'and',
+    'cent' => 'cent',
+    'cents' => 'cents',
+
+    'currencies' => [
+        'AUD' => [
+            'singular' => 'australian dollar',
+            'plural' => 'australian dollars',
+        ],
+        'BRL' => [
+            'singular' => 'real',
+            'plural' => 'reais',
+        ],
+        'CAD' => [
+            'singular' => 'canadian dollar',
+            'plural' => 'canadian dollars',
+        ],
+        'EUR' => [
+            'singular' => 'euro',
+            'plural' => 'euros',
+        ],
+        'JPY' => [
+            'singular' => 'yen',
+            'plural' => 'yens',
+        ],
+        'USD' => [
+            'singular' => 'dollar',
+            'plural' => 'dollars',
+        ],
+    ],
+
+];

--- a/resources/lang/pt_BR/number.php
+++ b/resources/lang/pt_BR/number.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | LaravelToolkit Language Lines
+    |--------------------------------------------------------------------------
+    |
+    */
+
+    'and' => 'e',
+    'cent' => 'centavo',
+    'cents' => 'centavos',
+
+    'currencies' => [
+        'AUD' => [
+            'singular' => 'dólar australiano',
+            'plural' => 'dólares australiano',
+        ],
+        'BRL' => [
+            'singular' => 'real',
+            'plural' => 'reais',
+        ],
+        'CAD' => [
+            'singular' => 'dólar canadense',
+            'plural' => 'dólares canadense',
+        ],
+        'EUR' => [
+            'singular' => 'euro',
+            'plural' => 'euros',
+        ],
+        'JPY' => [
+            'singular' => 'yen',
+            'plural' => 'yens',
+        ],
+        'USD' => [
+            'singular' => 'dólar',
+            'plural' => 'dólares',
+        ],
+    ],
+
+];

--- a/src/LaravelToolkitServiceProvider.php
+++ b/src/LaravelToolkitServiceProvider.php
@@ -13,6 +13,7 @@ use LaravelToolkit\Facades\ACL;
 use LaravelToolkit\Macros\BlueprintMacro;
 use LaravelToolkit\Macros\BuilderMacro;
 use LaravelToolkit\Macros\CollectionMacro;
+use LaravelToolkit\Macros\NumberMacro;
 use LaravelToolkit\Macros\RequestMacro;
 use LaravelToolkit\Macros\RouterMacro;
 use LaravelToolkit\Macros\StrMacro;
@@ -91,6 +92,7 @@ class LaravelToolkitServiceProvider extends PackageServiceProvider
         (new BlueprintMacro)();
         (new BuilderMacro)();
         (new CollectionMacro)();
+        (new NumberMacro)();
         (new RequestMacro)();
         (new RouterMacro)();
         (new StrMacro)();

--- a/src/Macros/NumberMacro.php
+++ b/src/Macros/NumberMacro.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LaravelToolkit\Macros;
+
+use Illuminate\Support\Number;
+
+class NumberMacro
+{
+    public function __invoke(): void
+    {
+        $this->spellCurrency();
+    }
+
+    public function spellCurrency(): void
+    {
+        Number::macro('spellCurrency', function (
+            int|float $number,
+            ?string $in = null,
+            ?string $locale = null
+        ): string {
+            $int = intval(floor($number));
+            $decimals = intval(floor((($number - $int) * 100)));
+
+            $locale = $locale ?? app()->getLocale();
+
+            $in = $in ?? Number::defaultCurrency();
+
+            $singularKey = "laraveltoolkit::number.currencies.{$in}.singular";
+            $pluralKey = "laraveltoolkit::number.currencies.{$in}.plural";
+
+            $singularName = str(__($singularKey))->replace($singularKey, $in)->toString();
+            $pluralName = str(__($pluralKey))->replace($pluralKey, $in)->toString();
+
+            $spelled = [];
+            $spelled[] = Number::spell($int, $locale);
+            $spelled[] = ($int !== 1 ? $pluralName : $singularName);
+            if ($decimals !== 0) {
+                $spelled[] = __('laraveltoolkit::number.and');
+                $spelled[] = Number::spell($decimals, $locale);
+                $spelled[] = ($decimals !== 1 ? __('laraveltoolkit::number.cents') : __('laraveltoolkit::number.cent'));
+            }
+
+            return implode(' ', $spelled);
+        });
+    }
+}

--- a/tests/Macros/NumberTest.php
+++ b/tests/Macros/NumberTest.php
@@ -1,0 +1,14 @@
+<?php
+
+it('can spell', function () {
+    expect(Number::spellCurrency(1))
+        ->toEqual('um dólar')
+        ->and(Number::spellCurrency(2))
+        ->toEqual('dois dólares')
+        ->and(Number::spellCurrency(2))
+        ->toEqual('dois dólares')
+        ->and(Number::spellCurrency(0.43))
+        ->toEqual('zero dólares e quarenta e três centavos')
+        ->and(Number::spellCurrency(1_432_321.52))
+        ->toEqual('um milhão quatrocentos e trinta e dois mil trezentos e vinte e um dólares e cinquenta e dois centavos');
+});


### PR DESCRIPTION
Introduces `NumberMacro` to spell out currency values in words, supporting multiple locales and currencies. Includes tests and language files for English and Brazilian Portuguese, and adds `ext-intl` to runtime dependencies.