### PR TITLE
Upgrade test suite to Pest 5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,8 @@ name: run-tests
 
 on:
   push:
+    branches:
+      - '3.x'
     paths:
       - '**.php'
       - '.github/workflows/run-tests.yml'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,17 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+  pull_request:
+    paths:
+      - '**.php'
+      - '.github/workflows/run-tests.yml'
+      - 'phpunit.xml.dist'
+      - 'composer.json'
+      - 'composer.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,20 +29,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.5 ]
-        laravel: [ ^13.0, ^12.25 ]
+        php: [ 8.4, 8.5 ]
+        laravel: [ ^13.20, ^12.25 ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: ^13.0
-            testbench: 11.*
+          - laravel: ^13.20
+            testbench: ^11.1
+            pest: ^5.0
+            pest-arch: ^5.0
+            pest-laravel: ^5.0
           - laravel: ^12.25
             testbench: ^10.6
+            pest: ^4.0
+            pest-arch: ^4.0
+            pest-laravel: ^4.0
 
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -51,18 +68,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer remove pestphp/pest pestphp/pest-plugin-arch pestphp/pest-plugin-laravel --dev --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-arch:${{ matrix.pest-arch }}" "pestphp/pest-plugin-laravel:${{ matrix.pest-laravel }}" --dev --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D
 
       - name: Execute tests
-        run: ./vendor/bin/pest
+        run: composer test -- --ci
 
   coverage:
-    needs: test
-    name: Tests and coverage
+    name: Coverage (PHP 8.5 - Laravel 13)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -73,7 +90,7 @@ jobs:
         with:
           php-version: '8.5'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: "xdebug"
+          coverage: pcov
 
       - name: Setup problem matchers
         run: |
@@ -82,13 +99,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:13.*" "orchestra/testbench:11.*" "nesbot/carbon:^3.0" --no-interaction --no-update
+          composer require "laravel/framework:^13.20" "orchestra/testbench:^11.1" "nesbot/carbon:^3.0" --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D
+
       - name: Execute coverage
-        run: php -dxdebug.mode=coverage ./vendor/bin/pest --coverage-clover ./.build/cache/coverage.xml
+        run: composer test-coverage -- --ci --coverage-clover=./.build/cache/coverage.xml
+
       - name: "Publish coverage report to Codecov"
         uses: "codecov/codecov-action@v7.0.0"
         with:

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     "laravel/pint": "^v1.29.0",
     "nunomaduro/collision": "^8.8.2",
     "orchestra/testbench": "^10.6.0||^v11.1.0",
-    "pestphp/pest": "^v4.5.0",
-    "pestphp/pest-plugin-arch": "^v4.0.2",
-    "pestphp/pest-plugin-laravel": "^v4.1.0",
+    "pestphp/pest": "^v5.0.0",
+    "pestphp/pest-plugin-arch": "^v5.0.0",
+    "pestphp/pest-plugin-laravel": "^v5.0.0",
     "spatie/laravel-ray": "^1.43.7"
   },
   "autoload": {
@@ -54,9 +54,9 @@
     "post-autoload-dump": "@composer run prepare",
     "prepare": "@php vendor/bin/testbench package:discover --ansi",
     "analyse": "vendor/bin/phpstan analyse",
-    "test": "vendor/bin/pest",
-    "test-dirty": "vendor/bin/pest --dirty",
-    "test-coverage": "vendor/bin/pest --coverage",
+    "test": "vendor/bin/pest --parallel",
+    "test-dirty": "vendor/bin/pest --parallel --dirty",
+    "test-coverage": "@php -d memory_limit=1G vendor/bin/pest --parallel --coverage --exactly=100",
     "format": "vendor/bin/pint"
   },
   "config": {

--- a/src/Filepond/UploadedFile.php
+++ b/src/Filepond/UploadedFile.php
@@ -87,23 +87,17 @@ class UploadedFile extends \Illuminate\Http\UploadedFile
             return $target;
         }
 
-        switch ($this->getError()) {
-            case \UPLOAD_ERR_INI_SIZE:
-                throw new IniSizeFileException($this->getErrorMessage());
-            case \UPLOAD_ERR_FORM_SIZE:
-                throw new FormSizeFileException($this->getErrorMessage());
-            case \UPLOAD_ERR_PARTIAL:
-                throw new PartialFileException($this->getErrorMessage());
-            case \UPLOAD_ERR_NO_FILE:
-                throw new NoFileException($this->getErrorMessage());
-            case \UPLOAD_ERR_CANT_WRITE:
-                throw new CannotWriteFileException($this->getErrorMessage());
-            case \UPLOAD_ERR_NO_TMP_DIR:
-                throw new NoTmpDirFileException($this->getErrorMessage());
-            case \UPLOAD_ERR_EXTENSION:
-                throw new ExtensionFileException($this->getErrorMessage());
-        }
+        $message = $this->getErrorMessage();
 
-        throw new FileException($this->getErrorMessage());
+        throw match ($this->getError()) {
+            \UPLOAD_ERR_INI_SIZE => new IniSizeFileException($message),
+            \UPLOAD_ERR_FORM_SIZE => new FormSizeFileException($message),
+            \UPLOAD_ERR_PARTIAL => new PartialFileException($message),
+            \UPLOAD_ERR_NO_FILE => new NoFileException($message),
+            \UPLOAD_ERR_CANT_WRITE => new CannotWriteFileException($message),
+            \UPLOAD_ERR_NO_TMP_DIR => new NoTmpDirFileException($message),
+            \UPLOAD_ERR_EXTENSION => new ExtensionFileException($message),
+            default => new FileException($message),
+        };
     }
 }

--- a/tests/Actions/Filepond/FetchTest.php
+++ b/tests/Actions/Filepond/FetchTest.php
@@ -1,7 +1,14 @@
 <?php
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+
 it('can fetch an image', function () {
-    $url = 'https://fastly.picsum.photos/id/1001/200/300.jpg?hmac=nQhEVl6C7qyfiRmcIe41BohR4WBcN1yhONnlCJryahU';
+    $url = 'https://example.test/image.jpg';
+    $image = UploadedFile::fake()->image('image.jpg');
+
+    Http::fake([$url => Http::response($image->getContent())]);
+
     $this->get(route('lt.filepond.fetch', ['url' => $url]))
         ->assertSuccessful()
         ->assertHeader('Access-Control-Expose-Headers', 'Content-Disposition, Content-Length, X-Content-Transfer-Id')
@@ -12,7 +19,9 @@ it('can fetch an image', function () {
 });
 
 it('can\'t fetch an image due wrong url', function () {
-    $url = 'https://foo.bar';
+    Http::fake(Http::failedConnection());
+
+    $url = 'https://invalid.example.test';
     $this->get(route('lt.filepond.fetch', ['url' => $url]))
         ->assertNotFound();
 });

--- a/tests/Actions/Filepond/LoadTest.php
+++ b/tests/Actions/Filepond/LoadTest.php
@@ -1,7 +1,14 @@
 <?php
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+
 it('can fetch an image', function () {
-    $url = 'https://fastly.picsum.photos/id/1001/200/300.jpg?hmac=nQhEVl6C7qyfiRmcIe41BohR4WBcN1yhONnlCJryahU';
+    $url = 'https://example.test/image.jpg';
+    $image = UploadedFile::fake()->image('image.jpg');
+
+    Http::fake([$url => Http::response($image->getContent())]);
+
     $this->get(route('lt.filepond.load', ['source' => $url]))
         ->assertSuccessful()
         ->assertHeader('Content-Type')
@@ -10,7 +17,9 @@ it('can fetch an image', function () {
 });
 
 it('can\'t fetch an image due wrong url', function () {
-    $url = 'https://foo.bar';
+    Http::fake(Http::failedConnection());
+
+    $url = 'https://invalid.example.test';
     $this->get(route('lt.filepond.load', ['source' => $url]))
         ->assertNotFound();
 });

--- a/tests/DataAdapterTest.php
+++ b/tests/DataAdapterTest.php
@@ -1,8 +1,21 @@
 <?php
 
+use Illuminate\Database\MySqlConnection;
+use Laraveltoolkit\DataAdapter\MatchMode;
 use Laraveltoolkit\Tests\Model\Product;
 use Laraveltoolkit\Tests\Model\User;
 use Laraveltoolkit\Tests\UserResource;
+
+it('uses the MySQL text cast for textual filters', function () {
+    $query = new MySqlConnection(null, '', '', ['driver' => 'mysql'])->query();
+
+    MatchMode::CONTAINS->apply($query, 'name', 'FOO', 'and');
+
+    expect($query->toSql())
+        ->toBe('select * where LOWER(CAST(`name` AS CHAR)) LIKE ?')
+        ->and($query->getBindings())
+        ->toBe(['%foo%']);
+});
 
 it('test base functionality', function () {
     User::factory()->count(100)->create();

--- a/tests/Filepond/GarbageCollectorTest.php
+++ b/tests/Filepond/GarbageCollectorTest.php
@@ -13,7 +13,7 @@ it('test the garbage collector', function () {
     $id = Str::uuid()->toString();
     $path = Filepond::path($id, 'foo.bar');
     $disk->put($path, 'test');
-    sleep(1);
+    $this->travel(1)->second();
 
     Filepond::garbageCollector();
 

--- a/tests/Filepond/UploadedFileTest.php
+++ b/tests/Filepond/UploadedFileTest.php
@@ -12,117 +12,78 @@ use Symfony\Component\HttpFoundation\File\Exception\NoTmpDirFileException;
 use Symfony\Component\HttpFoundation\File\Exception\PartialFileException;
 use Symfony\Component\HttpFoundation\File\File;
 
-it('test from id method on not valid values', function () {
-    $empty1 = UploadedFile::fromId('');
-    $empty2 = UploadedFile::fromId(null);
-    $empty3 = UploadedFile::fromId(Str::uuid());
-    $empty4 = UploadedFile::fromId('not a valid uuid');
+it('creates, validates and moves uploaded files', function () {
+    $disk = Storage::fake(Filepond::diskName());
 
-    expect($empty1)
+    expect(UploadedFile::fromId(''))
         ->toBeNull()
-        ->and($empty2)
+        ->and(UploadedFile::fromId(null))
         ->toBeNull()
-        ->and($empty3)
+        ->and(UploadedFile::fromId(Str::uuid()))
         ->toBeNull()
-        ->and($empty4)
+        ->and(UploadedFile::fromId('not a valid uuid'))
         ->toBeNull();
-});
 
-it('can get from id', function () {
     $id = Str::uuid();
-    $diskName = Filepond::diskName();
-    $disk = Storage::fake($diskName);
     $disk->put(Filepond::path($id, 'image.png'), 'foo bar');
-
     $file = UploadedFile::fromId($id);
 
     expect($file)
         ->toBeInstanceOf(UploadedFile::class)
         ->and($file->isValid())
         ->toBeTrue()
-        ->and($file->move($disk->path('tmp')))
+        ->and($file->move($disk->path('tmp/from-id')))
         ->toBeInstanceOf(File::class);
 
-});
-
-it('can move on test file', function () {
     $id = Str::uuid();
-    $diskName = Filepond::diskName();
-    $disk = Storage::fake($diskName);
-    $disk->put(Filepond::path($id, 'image.png'), 'foo bar');
-    $file = new UploadedFile($disk->path(Filepond::path($id, 'image.png')), 'image.png', test: true);
-    expect($file)
-        ->toBeInstanceOf(UploadedFile::class)
-        ->and($file->isValid())
+    $path = Filepond::path($id, 'image.png');
+    $disk->put($path, 'foo bar');
+    $testFile = new UploadedFile($disk->path($path), 'image.png', test: true);
+
+    expect($testFile->isValid())
         ->toBeTrue()
-        ->and($file->move($disk->path('tmp')))
+        ->and($testFile->move($disk->path('tmp/test-file')))
         ->toBeInstanceOf(File::class);
-});
 
-it('can\'t move', function () {
     $id = Str::uuid();
-    $diskName = Filepond::diskName();
-    $disk = Storage::fake($diskName);
-    $disk->put(Filepond::path($id, 'image.png'), 'foo bar');
-    $file = UploadedFile::fromId($id);
-    $disk->delete(Filepond::path($id, 'image.png'));
+    $path = Filepond::path($id, 'image.png');
+    $disk->put($path, 'foo bar');
+    $unmovableFile = UploadedFile::fromId($id);
+    $disk->delete($path);
+    new ReflectionClass($unmovableFile)->getProperty('forceValidOnTest')->setValue($unmovableFile, true);
 
-    $reflection = new ReflectionClass($file);
-
-    $reflection->getProperty('forceValidOnTest')->setValue($file, true);
-
-    expect($file)
-        ->toBeInstanceOf(UploadedFile::class)
-        ->and($file->isValid())
+    expect($unmovableFile->isValid())
         ->toBeTrue()
-        ->and(fn () => $file->move($disk->path('foo-bar/test')))
-        ->toThrow(FileException::class);
-});
-
-it('can\'t move with other errors', function () {
-    $id = Str::uuid();
-    $diskName = Filepond::diskName();
-    $disk = Storage::fake($diskName);
-    $disk->put(Filepond::path($id, 'image.png'), 'foo bar');
-    $file = UploadedFile::fromId($id);
-
-    expect($file)
-        ->toBeInstanceOf(UploadedFile::class)
-        ->and($file->isValid())
-        ->toBeTrue()
-        ->and($file->move($disk->path('tmp')))
-        ->toBeInstanceOf(File::class)
-        ->and(fn () => $file->move($disk->path('tmp')))
+        ->and(fn () => $unmovableFile->move($disk->path('missing/directory')))
         ->toThrow(FileException::class);
 
-    $reflection = new ReflectionClass(Symfony\Component\HttpFoundation\File\UploadedFile::class);
-    $property = $reflection->getProperty('error');
+    $id = Str::uuid();
+    $path = Filepond::path($id, 'image.png');
+    $disk->put($path, 'foo bar');
+    $invalidFile = UploadedFile::fromId($id);
+    $invalidFile->move($disk->path('tmp/errors'));
 
-    $property->setValue($file, UPLOAD_ERR_INI_SIZE);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(IniSizeFileException::class);
+    expect(fn () => $invalidFile->move($disk->path('tmp/errors')))
+        ->toThrow(FileException::class);
 
-    $property->setValue($file, UPLOAD_ERR_FORM_SIZE);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(FormSizeFileException::class);
+    $errorProperty = new ReflectionClass(Symfony\Component\HttpFoundation\File\UploadedFile::class)
+        ->getProperty('error');
 
-    $property->setValue($file, UPLOAD_ERR_PARTIAL);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(PartialFileException::class);
+    foreach ([
+        UPLOAD_ERR_INI_SIZE => IniSizeFileException::class,
+        UPLOAD_ERR_FORM_SIZE => FormSizeFileException::class,
+        UPLOAD_ERR_PARTIAL => PartialFileException::class,
+        UPLOAD_ERR_NO_FILE => NoFileException::class,
+        UPLOAD_ERR_CANT_WRITE => CannotWriteFileException::class,
+        UPLOAD_ERR_NO_TMP_DIR => NoTmpDirFileException::class,
+        UPLOAD_ERR_EXTENSION => ExtensionFileException::class,
+    ] as $error => $exception) {
+        $errorProperty->setValue($invalidFile, $error);
 
-    $property->setValue($file, UPLOAD_ERR_NO_FILE);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(NoFileException::class);
+        expect(fn () => $invalidFile->move($disk->path('tmp/errors')))
+            ->toThrow($exception);
+    }
 
-    $property->setValue($file, UPLOAD_ERR_CANT_WRITE);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(CannotWriteFileException::class);
-
-    $property->setValue($file, UPLOAD_ERR_NO_TMP_DIR);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(NoTmpDirFileException::class);
-
-    $property->setValue($file, UPLOAD_ERR_EXTENSION);
-    expect(fn () => $file->move($disk->path('tmp')))
-        ->toThrow(ExtensionFileException::class);
+    defer()->invoke();
+    expect($disk->directoryMissing(Filepond::path($id)))->toBeTrue();
 });

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,19 @@
+<?php
+
+it('can safely load the helpers more than once', function () {
+    require dirname(__DIR__).'/src/helpers.php';
+
+    expect([
+        'floatToBcNumber',
+        'length',
+        'weight',
+        'volume',
+        'area',
+        'temperature',
+        'speed',
+        'duration',
+        'pressure',
+        'energy',
+        'power',
+    ])->each->toBeCallable();
+});

--- a/tests/Macros/CollectionTest.php
+++ b/tests/Macros/CollectionTest.php
@@ -44,6 +44,8 @@ it('test collator sort with natural values', function () {
 
     expect($collection->collatorSort(SORT_NATURAL)->values()->all())
         ->toBe(['item 1', 'item 2', 'item 10'])
+        ->and($collection->collatorSort(SORT_NATURAL | SORT_FLAG_CASE)->values()->all())
+        ->toBe(['item 1', 'item 2', 'item 10'])
         ->and($collection->collatorSort(SORT_NATURAL, SORT_DESC)->values()->all())
         ->toBe(['item 10', 'item 2', 'item 1']);
 });

--- a/tests/StoredAssets/JobsTest.php
+++ b/tests/StoredAssets/JobsTest.php
@@ -1,10 +1,46 @@
 <?php
 
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\UploadedFile;
 use Laraveltoolkit\Facades\StoredAssets;
+use Laraveltoolkit\StoredAssets\Jobs\GarbageCollector;
 use Laraveltoolkit\StoredAssets\Jobs\GarbageCollectorManager;
 use Laraveltoolkit\StoredAssets\Jobs\TrashBinCleaner;
+use Laraveltoolkit\StoredAssets\StoredAssetModel;
 use Laraveltoolkit\Tests\Model\Product;
+
+it('uses the optimized suffix lookup on MySQL', function () {
+    $disk = Storage::fake('local');
+    $uuid = Str::uuid()->toString();
+    $assetPath = StoredAssets::path($uuid, 'test.txt');
+    $disk->put($assetPath, 'content');
+
+    $connection = Mockery::mock(ConnectionInterface::class);
+    $connection->shouldReceive('getDriverName')->once()->andReturn('mysql');
+
+    $model = Mockery::mock(StoredAssetModel::class)->makePartial();
+    $model->shouldReceive('getConnection')->once()->andReturn($connection);
+
+    $query = Mockery::mock(Builder::class);
+    $query->shouldReceive('where')->once()->with('id_suffix', substr($uuid, -4))->andReturnSelf();
+    $query->shouldReceive('selectRaw')->once()->andReturnSelf();
+    $query->shouldReceive('groupBy')->once()->with('field_model')->andReturnSelf();
+    $query->shouldReceive('get')->once()->andReturn(collect());
+
+    $originalStoredAssets = StoredAssets::getFacadeRoot();
+
+    try {
+        $storedAssets = StoredAssets::partialMock();
+        $storedAssets->shouldReceive('newModel')->once()->with([])->andReturn($model);
+        $storedAssets->shouldReceive('modelQuery')->once()->andReturn($query);
+        $storedAssets->shouldReceive('moveToTrashBin')->once()->with('local', $uuid)->andReturnFalse();
+
+        new GarbageCollector('local', dirname($assetPath, 3))->handle();
+    } finally {
+        StoredAssets::swap($originalStoredAssets);
+    }
+});
 
 it('can run all jobs', function () {
     config()->set('laraveltoolkit.stored_assets.trash_bin_cleaner_timeout', 55);

--- a/tests/Support/HasTimeoutHandlerTest.php
+++ b/tests/Support/HasTimeoutHandlerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Laraveltoolkit\Support\HasTimeoutHandler;
+
+it('has a safe default timeout', function () {
+    $handler = new class
+    {
+        use HasTimeoutHandler;
+
+        public function safeTimeoutInSeconds(): int
+        {
+            return $this->safeTimeout();
+        }
+    };
+
+    expect($handler->safeTimeoutInSeconds())->toBe(55);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,7 +58,8 @@ class TestCase extends Orchestra
         config()->set('database.default', 'testing');
         config()->set('app.locale', 'pt_BR');
         config()->set('app.key', 'base64:Z1sxfk3d54CWnssAxvEFshoZVGmAO7KrbZGMzU5xko4=');
-        config()->set('app.maintenance.driver', 'array');
+        config()->set('app.maintenance.driver', 'cache');
+        config()->set('app.maintenance.store', 'array');
 
         $migrationStoredAsset = include __DIR__.'/../database/migrations/create_stored_assets_table.php.stub';
         $migrationStoredAsset->up();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,6 +58,7 @@ class TestCase extends Orchestra
         config()->set('database.default', 'testing');
         config()->set('app.locale', 'pt_BR');
         config()->set('app.key', 'base64:Z1sxfk3d54CWnssAxvEFshoZVGmAO7KrbZGMzU5xko4=');
+        config()->set('app.maintenance.driver', 'array');
 
         $migrationStoredAsset = include __DIR__.'/../database/migrations/create_stored_assets_table.php.stub';
         $migrationStoredAsset->up();


### PR DESCRIPTION
## Summary

- Upgrade Pest and the official plugins to v5 for Laravel 13.
- Run the test suite in parallel by default.
- Make tests deterministic by removing external HTTP requests and isolating maintenance mode state per process.
- Enforce exact 100% code coverage in parallel.
- Avoid duplicate GitHub Actions runs when a pull request branch is updated.

## Compatibility

- Laravel 13 runs with Pest 5 and Testbench 11.
- Laravel 12 remains covered with Pest 4 and Testbench 10 because its current dependency constraints are incompatible with Pest 5.
- The CI matrix covers PHP 8.4 and 8.5 using both `prefer-lowest` and `prefer-stable` dependencies.

## Performance

- Sequential baseline: ~53 seconds.
- Parallel execution with 10 processes: ~17 seconds.

## Validation

- 532 tests and 2,150 assertions passing.
- Exact 100.0% coverage in parallel.
- Full Laravel 12/13 and PHP 8.4/8.5 GitHub Actions matrix passing.
- Pint and strict Composer validation passing.
