### PR TITLE
docs: overhaul package documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for helping improve Laravel Toolkit.
+
+## Development setup
+
+Fork and clone the repository, then install its PHP dependencies:
+
+```bash
+composer install
+```
+
+The package uses Orchestra Testbench, so a separate Laravel application is not required for the test suite.
+
+## Before opening a pull request
+
+Run the formatter and test suite:
+
+```bash
+composer format
+composer test
+```
+
+Please keep each pull request focused, add or update tests for behavioral changes, and update the relevant guide when
+the public API or setup process changes. Do not edit `CHANGELOG.md` for unreleased changes unless a maintainer asks you
+to do so; release automation manages version entries.
+
+## Reporting bugs
+
+Use a GitHub issue for reproducible bugs and include:
+
+- the Laravel Toolkit, Laravel, PHP, and Inertia versions;
+- the smallest example that reproduces the behavior;
+- the expected and actual results;
+- the relevant exception and stack trace, with secrets removed.
+
+Security issues must be reported privately through a
+[GitHub security advisory](https://github.com/wsssoftware/laraveltoolkit/security/advisories/new).
+
+---
+
+[Back to the project README](README.md)

--- a/README.md
+++ b/README.md
@@ -1,99 +1,123 @@
-# A modern toolkit of components and utilities for Laravel applications, developed by WSS Software.
+# Laravel Toolkit
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/wsssoftware/laraveltoolkit.svg?style=flat-square)](https://packagist.org/packages/wsssoftware/laraveltoolkit)
-[![run-tests](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/run-tests.yml/badge.svg?branch=2.x)](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/run-tests.yml)
-[![Fix PHP code style issues](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/fix-php-code-style-issues.yml/badge.svg)](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/fix-php-code-style-issues.yml)
+[![Tests](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/run-tests.yml/badge.svg?branch=3.x)](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/run-tests.yml)
+[![Code Style](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/fix-php-code-style-issues.yml/badge.svg)](https://github.com/wsssoftware/laraveltoolkit/actions/workflows/fix-php-code-style-issues.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/wsssoftware/laraveltoolkit.svg?style=flat-square)](https://packagist.org/packages/wsssoftware/laraveltoolkit)
-[![codecov](https://codecov.io/gh/wsssoftware/laraveltoolkit/branch/2.x/graph/badge.svg?token=nzaXcoyc3q)](https://codecov.io/gh/wsssoftware/laraveltoolkit)
+[![Code Coverage](https://codecov.io/gh/wsssoftware/laraveltoolkit/branch/3.x/graph/badge.svg?token=nzaXcoyc3q)](https://codecov.io/gh/wsssoftware/laraveltoolkit)
 
-This is where your description should go. Limit it to a paragraph or two. Consider adding a small example.
+A practical collection of production-ready building blocks for Laravel applications. Laravel Toolkit combines typed
+measurements, ACL, stored assets, SEO and sitemap generation, FilePond uploads, deployment helpers, validation rules,
+and small framework extensions behind one package.
+
+Use only the features your application needs. The service provider is discovered automatically and registers the
+package configuration, routes, migrations, commands, views, translations, and macros.
 
 > [!IMPORTANT]
-> Some features from this package work in association with the
-> package [vuetoolkit](https://github.com/wsssoftware/vuetoolkit). For mor information read it's related docs.
+> The Vue, Inertia, and PrimeVue examples use the companion
+> [Vuetoolkit](https://github.com/wsssoftware/vuetoolkit) package. Backend-only features do not require it.
 
-## Compatibility
+## Requirements
 
-| Package Version | Vuetoolkit Version | Laravel Version | Inertia Version |
-|-----------------|--------------------|-----------------|-----------------|
-| 1.x             | ❌                  | `11.x` `12.x`   | `1.x` `2.x`     |
-| 2.x             | `1.x`              | `11.x` `12.x`   | `2.x`           |           
-| 3.x             | `2.x`              | `12.x` `13.x`   | `3.x`           |           
+- PHP 8.4 or newer
+- Laravel 12 or 13
+- Inertia Laravel 3
+- PHP extensions: BCMath, DOM, and Intl
+- Vuetoolkit 2.x only when using the companion frontend components
+
+| Laravel Toolkit | Laravel | Inertia Laravel | Vuetoolkit |
+|:---------------:|:-------:|:---------------:|:----------:|
+| 3.x | 12.x, 13.x | 3.x | 2.x |
+| 2.x | 11.x, 12.x | 2.x | 1.x |
+| 1.x | 11.x, 12.x | 1.x, 2.x | — |
 
 ## Installation
 
-You can install the package via composer:
+Install the package with Composer:
 
 ```bash
 composer require wsssoftware/laraveltoolkit
 ```
 
-You can publish the config file with:
+Publish the configuration when you need to change defaults:
 
 ```bash
-php artisan vendor:publish --tag="laraveltoolkit-config"
+php artisan vendor:publish --tag=laraveltoolkit-config
 ```
 
-You can publish the sitemap config file with:
+Features backed by database tables, such as ACL and Stored Assets, also need the package migrations:
 
 ```bash
-php artisan vendor:publish --tag="laraveltoolkit-sitemap"
+php artisan vendor:publish --tag=laraveltoolkit-migrations
+php artisan migrate
 ```
 
-This is the contents of the published config file:
+## Quick start
+
+The package is a toolkit rather than a single workflow. These examples show a few features that work immediately
+after installation:
 
 ```php
-return [
-];
+use Illuminate\Support\Number;
+use Illuminate\Support\Str;
+use Laraveltoolkit\Measurement\Enums\LengthUnit;
+use Laraveltoolkit\Rules\DocumentRule;
+
+length(2.54, 'cm')->to(LengthUnit::MILLIMETER)->value(); // 25.4
+
+Str::applyMask('12345678901', '000.000.000-00'); // 123.456.789-01
+
+Number::spellCurrency(42.50, in: 'BRL', locale: 'pt_BR');
+
+$request->validate([
+    'document' => ['required', DocumentRule::both()],
+]);
 ```
 
-## Usage
+For an application feature, choose a guide below and follow its setup section.
 
-### [ACL](docs/ACL.md)
+## Features
 
-A minimalist implementation of an access control level
+### Application building blocks
 
-### [Colors](docs/COLORS.md)
+| Feature | What it provides |
+|---|---|
+| [Measurements](docs/MEASUREMENT.md) | Precise value objects, conversion, formatting, arithmetic, and Eloquent casts for ten measurement dimensions. |
+| [ACL](docs/ACL.md) | Database-backed policies and roles integrated with Laravel Gate and optional Vue components. |
+| [Stored Assets](docs/STORED_ASSETS.md) | Recipe-driven file storage, Eloquent casts, multiple asset variants, and garbage collection. |
+| [Utilities](docs/UTILITIES.md) | CPF/CNPJ and phone validation, enum helpers, regex utilities, framework macros, and extended fluent objects. |
 
-A toolset of helpers for colors.
+### Inertia and frontend integrations
 
-### [Deploy](docs/DEPLOY.md)
+| Feature | What it provides |
+|---|---|
+| [PrimeVue Data](docs/PRIMEVUE_DATA.md) | Server-side filtering, sorting, and pagination for PrimeVue DataTable and DataView. |
+| [FilePond](docs/FILEPOND.md) | Temporary, chunked uploads with request conversion to Laravel uploaded files. |
+| [Flash](docs/FLASH.md) | Chainable session messages consumed by the Vuetoolkit PrimeVue toast receiver. |
+| [Multi-domain Inertia](docs/MULTI_DOMAIN.md) | Cross-domain Inertia redirect handling and the required CORS setup. |
 
-A simple deploy and maintenance mode.
+### SEO and operations
 
-### [Flash](docs/FLASH.md)
+| Feature | What it provides |
+|---|---|
+| [SEO](docs/SEO.md) | Server- and client-rendered metadata, Open Graph, Twitter cards, robots directives, and `robots.txt`. |
+| [Sitemap](docs/SITEMAP.md) | Cached XML sitemaps, domain-specific entries, query chunking, and sitemap indexes. |
+| [Deploy](docs/DEPLOY.md) | Two-stage deployment commands and a broadcast-aware Inertia maintenance page. |
 
-Simple flash messages from backend to front end.
+See the [documentation index](docs/README.md) for the complete guide map and common setup commands.
 
-### [FilePond](docs/FILEPOND.md)
+## Configuration
 
-A bridge between FilePond and Laravel
+All package settings live in `config/laraveltoolkit.php` after publishing. They are grouped by feature:
 
-### [PrimeVue Data](docs/PRIMEVUE_DATA.md)
+- `deploy`: maintenance route and deployment actions
+- `flash`: default lifetime, closability, and toast group
+- `filepond`: temporary disk, path, and garbage collection
+- `seo`: metadata defaults and propagation
+- `sitemap`: routes, caching, timeouts, and XML limits
+- `stored_assets`: disk, model, paths, naming, and trash retention
 
-A minimalist implementation of DataTables and DataView on Laravel
-
-### [Measurement](docs/MEASUREMENT.md)
-
-Typed measurements with localized conversion and arbitrary-precision decimal arithmetic.
-
-### [SEO](docs/SEO.md)
-
-Tools to help dev to handle with SEO features.
-
-### [SiteMap](docs/SITEMAP.md)
-
-A toolkit to automatically generate sitemaps for application
-
-### [Stored Assets](docs/STORED_ASSETS.md)
-
-Tools to help handle with storing assets.
-
-## Multi domain application
-
-If you are using a multi-domain application with InertiaJs, you can use [this guide](docs/MULTI_DOMAIN.md) to configure
-your cors policies
-and add a middleware to replace redirects for Inertia::location() when needed.
+Only publish the configuration when you need to override these defaults.
 
 ## Testing
 
@@ -101,23 +125,30 @@ and add a middleware to replace redirects for Inertia::location() when needed.
 composer test
 ```
 
-## Changelog
+Code style can be checked and fixed with:
 
-Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.
+```bash
+composer format
+```
 
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+Contributions are welcome. Read the [contribution guide](CONTRIBUTING.md) before opening a pull request.
 
-## Security Vulnerabilities
+## Changelog
 
-Please review [our security policy](../../security/policy) on how to report security vulnerabilities.
+See the [changelog](CHANGELOG.md) for release history and upgrade notes.
+
+## Security
+
+Please report security vulnerabilities through the repository's
+[private security advisory form](https://github.com/wsssoftware/laraveltoolkit/security/advisories/new), not a public issue.
 
 ## Credits
 
 - [Allan Mariucci Carvalho](https://github.com/wsssoftware)
-- [All Contributors](../../contributors)
+- [All contributors](https://github.com/wsssoftware/laraveltoolkit/graphs/contributors)
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+Laravel Toolkit is open-source software licensed under the [MIT license](LICENSE.md).

--- a/docs/ACL.md
+++ b/docs/ACL.md
@@ -1,278 +1,263 @@
-## ACL
+# Access control (ACL)
 
-A minimalist implementation of an access control level
+The ACL module stores application-specific policies and optional roles in a one-to-one record for each user. It
+registers every rule and role as a normal Laravel Gate ability, so controllers, routes, Blade, and policies can use
+Laravel's standard authorization API.
 
-Before you need create vendor migrations running:
+Abilities follow these names:
+
+- policy rules: `{policy-column}::{rule-key}`, for example `users::update`;
+- roles: `roles::{enum-value}`, for example `roles::admin`.
+
+## Setup
+
+### 1. Publish and edit the migration
 
 ```bash
 php artisan vendor:publish --tag=laraveltoolkit-migrations
 ```
 
-after you must create table columns for each policy that you want.
+Before migrating, add one nullable JSON column for every policy. Keep `id`, `roles`, and `updated_at` as generated:
 
 ```php
-/// on database/migrations/2024_10_22_104112_create_user_permissions_table
- Schema::create('user_permissions', function (Blueprint $table) {
-    $table->id();
-    $table->foreignId('user_id')
-        ->unique()
+Schema::create('user_permissions', function (Blueprint $table) {
+    $table->foreignId('id')
+        ->primary()
         ->constrained('users')
         ->cascadeOnUpdate()
         ->cascadeOnDelete();
-    // User roles is an internal feature, don't use as a policy
-    $table->json('roles')->default('[]');
-    $table->json('users')->nullable(); // <-- HERE
-    $table->json('products')->nullable(); // <-- HERE
-    $table->json('categories')->nullable(); // <-- HERE
+
+    $table->json('roles');
+    $table->json('users')->nullable();
+    $table->json('products')->nullable();
     $table->timestamp('updated_at')->nullable();
-}
-//...
+});
 ```
 
-> You can create alter table after as you need to create more policy columns.
+The permission record intentionally shares its primary key with the user. Add new nullable JSON columns in a later
+migration whenever you introduce more policies.
 
-after make UserPermission model running command:
+```bash
+php artisan migrate
+```
+
+### 2. Generate the permission model
 
 ```bash
 php artisan make:acl-model
 ```
 
-Register it on you `AppServiceProvider`
+Declare policies inside the generated model:
+
+```php
+use Laraveltoolkit\ACL\UserPermission as BaseUserPermission;
+
+final class UserPermission extends BaseUserPermission
+{
+    protected function declarePoliciesAndRoles(): void
+    {
+        self::registryPolicy('users', 'Users', 'Manage application users')
+            ->crud()
+            ->export();
+
+        self::registryPolicy('products', 'Products', 'Manage the product catalog')
+            ->read()
+            ->create()
+            ->update()
+            ->rule('publish', 'Publish', 'Publish products');
+    }
+}
+```
+
+`crud()` adds `create`, `read`, `update`, and `delete`. Other shortcuts include `cancel`, `download`, `execute`,
+`export`, `import`, `print`, `share`, and `upload`. Use `rule()` for application-specific abilities. Each shortcut and
+`rule()` accepts an optional HTTP denial status.
+
+> [!NOTE]
+> The policy column declared in PHP must also exist as a nullable JSON column on `user_permissions`.
+
+### 3. Register the model
+
+Register the model before the application finishes booting, usually in `AppServiceProvider`:
 
 ```php
 use App\Models\UserPermission;
 use Laraveltoolkit\Facades\ACL;
 
-//...
 public function boot(): void
 {
     ACL::withModel(UserPermission::class);
-    // if you want to use role system, create a string enum and declare its FQN here
-     ACL::withModel(UserPermission::class)
-            ->withRolesEnum(UserRole::class);
 }
 ```
 
-> Role Enum is a more generic way to allow or deny user to access some part of your application.
-> It must be a string Enum and implement `Laraveltoolkit\ACL\HasDenyResponse` interface to be used.
-
-On your `UserPermission` created model declare your firsts policies and rules:
+Add `HasUserPermission` to the authenticatable user model:
 
 ```php
-protected static function declarePoliciesAndRoles(): void
-{
-  self::registryPolicy('users', 'Users', 'Manage system users')
-      ->crud()
-      ->rule('export', 'Export', 'Export users')
-  // OR its equivalent
-  self::registryPolicy('users', 'Users', 'Manage system users')
-      ->rule('create', 'Create', 'Create users')
-      ->rule('read', 'Read', 'Read users')
-      ->rule('update', 'Update', 'Update users')
-      ->rule('delete', 'Delete', 'Delete users')
-      ->rule('export', 'Export', 'Export users');
-}
-```
-
-On your `User` Model add `HasUserPermission` trait to configure relations and other things:
-
-```php
-
+use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laraveltoolkit\ACL\HasUserPermission;
 
-class User extends Authenticatable
+final class User extends Authenticatable
 {
     use HasUserPermission;
+}
 ```
 
-To use gate on frontend registry it on `HandleInertiaRequests`
+The relation creates the user's empty permission record on first access.
+
+## Authorizing policy rules
+
+Use the generated abilities through Laravel Gate or the `can` middleware:
 
 ```php
+use Illuminate\Support\Facades\Gate;
 
+Gate::allows('users::read');
+Gate::authorize('products::publish');
+
+Route::post('/products', StoreProductController::class)
+    ->middleware('can:products::create');
+```
+
+## Editing permissions
+
+Permissions may be changed individually, in bulk, or by policy:
+
+```php
+$permissions = $user->userPermission;
+
+$permissions->grant('users::read')
+    ->grant('products::publish')
+    ->deny('users::delete')
+    ->save();
+
+$permissions->grantAll('products')->save();
+$permissions->denyAll('users')->save();
+
+$permissions->fillPolicies([
+    'users::create' => true,
+    'users::read' => true,
+    'users::update' => false,
+    'users::delete' => false,
+]);
+$permissions->save();
+```
+
+Calling `grantAll()` or `denyAll()` without a policy applies the change to every declared policy.
+
+## Roles
+
+Roles are optional and use a string-backed enum implementing `HasDenyResponse`:
+
+```php
+use Illuminate\Auth\Access\Response;
+use Laraveltoolkit\ACL\HasDenyResponse;
+
+enum UserRole: string implements HasDenyResponse
+{
+    case ADMIN = 'admin';
+    case SUPPORT = 'support';
+
+    public function denyResponse(): Response
+    {
+        return match ($this) {
+            self::ADMIN => Response::denyAsNotFound(),
+            self::SUPPORT => Response::denyWithStatus(403),
+        };
+    }
+}
+```
+
+Register it together with the permission model:
+
+```php
+ACL::withModel(UserPermission::class)
+    ->withRolesEnum(UserRole::class);
+```
+
+Then grant, revoke, and authorize roles:
+
+```php
+$permissions->grantRole(UserRole::ADMIN)->save();
+$permissions->denyRole(UserRole::SUPPORT)->save();
+$permissions->grantAllRoles()->save();
+$permissions->denyAllRoles()->save();
+
+Gate::authorize('roles::admin');
+```
+
+### Role middleware
+
+After registering a roles enum, the package exposes the `user_roles` middleware alias:
+
+```php
+// Require both roles.
+Route::middleware('user_roles:admin,support')->group(function () {
+    // ...
+});
+
+// Require support and reject users who also have admin.
+Route::middleware('user_roles:support,!admin')->group(function () {
+    // ...
+});
+```
+
+Every unprefixed role is required. Prefixing a role with `!` explicitly rejects users who have it.
+
+## Sharing permissions with Inertia
+
+Expose only Gate-ready boolean values from `HandleInertiaRequests`:
+
+```php
+use Illuminate\Http\Request;
 use Laraveltoolkit\Facades\ACL;
 
 public function share(Request $request): array
 {
     return [
         ...parent::share($request),
-        'auth' [
-            //...
-            'acl' => fn() => ACL::gatePermissions(),
+        'auth' => [
+            'user' => $request->user(),
+            'acl' => fn () => ACL::gatePermissions(),
         ],
     ];
 }
 ```
 
-### Editing an policy
-
-You can edit using:
+To build a permission editor, return the complete policy metadata from a controller:
 
 ```php
-$user = \Illuminate\Support\Facades\Auth::user();
-
-$userPermission = $user->userPermission
-
-$users = $userPermission->users->create->value = true;
-// OR
-$userPermission->users = [
-    'create' => true,
-    'read' => true,
-    'update' => true,
-    'delete' => true,
-];
-// OR
-$userPermission->fillPolicies([
-    'users::create' => true,
-    'users::read' => true,
-    'users::update' => true,
-    'users::delete' => true,
-]);
-// OR
-$userPermission->grantAll();
-// OR
-$userPermission->grantAll('users');
-// OR
-$userPermission->grant('users::create');
-// OR
-$userPermission->grantAllRoles();
-// OR
-$userPermission->grantRole(UserRole::ADMIN);
-// OR
-$userPermission->denyAll();
-// OR
-$userPermission->denyAll('users');
-// OR
-$userPermission->deny('users::create');
-// OR
-$userPermission->denyAllRoles();
-// OR
-$userPermission->denyRole(UserRole::ADMIN);
-//then
-$userPermission->save();
-```
-
-If you want edit on frontend:
-
-```php
-
-use Laraveltoolkit\Facades\ACL;
 use Laraveltoolkit\ACL\Policy;
-// on controller or equivalent
-public function create(=): Response
-{
-    return Inertia::render('Tests/Laraveltoolkit/ACL', [
-        'permissions' => ACL::permissions(),
-        // if you want to filter edit permissions available por users
-        'permissions' => ACL::permissions(filter: function (Policy $policy) {
-            return !str_starts_with($policy->column, 'admin_');
-        }),
-    ]);
-}
+use Laraveltoolkit\Facades\ACL;
 
-public function store(Request $request): RedirectResponse
-{
-    $up = \Illuminate\Support\Facades\Auth::user()->userPermission;
-    $up->fillPolicies($request->permissions);
-    $up->save();
-    return retirect()->route('index');
-}
+return Inertia::render('Users/Permissions', [
+    'permissions' => ACL::permissions(
+        filter: fn (Policy $policy) => ! str_starts_with($policy->column, 'internal_'),
+    ),
+]);
 ```
 
-```vue
-<template>
-    <form @submit.prevent="submit">
-        <UserPermissionsEditor v-model="form.permissions" :permissions="permissions"/>
-        <button type="submit">Enviar</button>
-    </form>
-</template>
-
-<script lang="ts">
-import {defineComponent, PropType} from "vue";
-import {UserPermissions, UserPermissionsEditor} from "laraveltoolkit";
-import {useForm} from "@inertiajs/vue3";
-
-export default defineComponent({
-    name: "ACL" ,
-    components: {UserPermissionsEditor},
-    props: {
-        permissions: {
-            type: Array as PropType<UserPermissions>,
-            required: true,
-        }
-    },
-    data() {
-        return {
-            form: useForm({
-                permissions: {}
-            }),
-        };
-    },
-    methods: {
-        submit(): void {
-            this.form.post(route('send'))
-        }
-    },
-});
-</script>
-```
-
-### Usage
-
-On backend, you will use like a normal gate, but pay attention on ability name:
-
-```php
-// Policy rule: policyColumn + :: + ruleName
-\Illuminate\Support\Facades\Gate::allows('users::create')
-// Role: roles :: + roleName
-\Illuminate\Support\Facades\Gate::allows('roles::admin')
-```
-
-On frontend, when you have been installed the VueJS plugin, you can use `$gate class`, `Gate component` or
-`Gate directive`.
+The companion Vuetoolkit package provides `UserPermissionsEditor`, the `$gate` helper, `Gate` component, and
+`v-gate` directive:
 
 ```vue
 <template>
     <Gate rule="allows" abilities="users::read">
-        <h1>Show this on has</h1>
-        <template #fallback>
-            <h1>Or show this on hasn't</h1>
-        </template>
+        <UsersTable />
+        <template #fallback>Access denied.</template>
     </Gate>
-    <button v-gate:allows="'users::read'">You see if you has</button>
-    <button v-gate:allows="'roles::admin'">You see if you has</button>
-    <button v-if="has">You see if you has</button>
+
+    <button v-gate:allows="'products::publish'">Publish</button>
+    <button v-if="$gate.allows('roles::admin')">Admin</button>
 </template>
-
-<script lang="ts">
-import {defineComponent} from "vue";
-import {GateDirective} from "laraveltoolkit";
-import {Gate} from "Laraveltoolkit";
-
-export default defineComponent({
-    name: "Example",
-    components: {Gate},
-    directives: {
-        gate: GateDirective,
-    },
-    computed: {
-        has(): boolean {
-            return this.$gate.allows('users.read')
-        }
-    },
-});
-</script>
 ```
 
-You can also use the `Middleware` to use a role to some route or route group:
+Treat frontend checks as presentation only; always authorize the corresponding action on the server.
 
-```php
-Route::prefix('admin-l1')->group(function() {
-// Your routes here
-})->middleware('user_roles:admin,admin_lvl2')
+## Testing
 
-Route::prefix('admin-l2')->group(function() {
-// Your routes here
-})->middleware('user_roles:admin_lvl2,!admin')
-```
+Laravel's normal authorization assertions and Gate calls work with ACL abilities. When testing permission changes,
+save the permission model before authorizing because Gate resolves the persisted user relation.
 
+---
 
+[Back to the documentation index](README.md)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,68 +1,174 @@
-## Deploy and Maintenance mode
+# Deploy and maintenance mode
 
-A toolset to help on deploy application and maintenance mode
+The deploy module provides an interactive two-stage release workflow for applications that use an Inertia maintenance
+screen. Stage 1 enables maintenance mode and updates backend code. Stage 2 builds assets, updates the database and
+caches, restarts long-running processes, then brings the application back online.
 
-First to use maintenance mode, if you use Laravel Echo events you must call function on your echo.js. Your file will be
-like this:
+> [!CAUTION]
+> The default workflow runs Git, Composer, npm, migrations, seeders, cache commands, Horizon, and PM2. Review and
+> customize `config/laraveltoolkit.php` before running it on a server. In production, the Git action discards local
+> tracked changes, and the Composer action runs `composer update --no-dev` rather than `composer install`.
+
+## Setup
+
+### 1. Publish and review the configuration
+
+```bash
+php artisan vendor:publish --tag=laraveltoolkit-config
+```
+
+The relevant defaults are:
+
+```php
+use Laraveltoolkit\Deploy\Commands\Actions\CacheApplication;
+use Laraveltoolkit\Deploy\Commands\Actions\ComposerUpdate;
+use Laraveltoolkit\Deploy\Commands\Actions\GitPull;
+use Laraveltoolkit\Deploy\Commands\Actions\MigrateDatabase;
+use Laraveltoolkit\Deploy\Commands\Actions\NpmUpdateAndBuild;
+use Laraveltoolkit\Deploy\Commands\Actions\Pm2Restart;
+use Laraveltoolkit\Deploy\Commands\Actions\SeedDatabase;
+use Laraveltoolkit\Deploy\Commands\Actions\TerminateHorizon;
+use Laraveltoolkit\Deploy\Intent;
+
+'deploy' => [
+    'domain' => env('APP_DOMAIN', 'localhost'),
+    'path' => '/maintenance',
+    'bypass_secret' => Str::password(10, true, true, false),
+    'inertia_component' => 'Maintenance',
+    'default_redirect' => '/',
+    'step1' => [
+        Intent::make(GitPull::class, ['--release' => '1.']),
+        Intent::make(ComposerUpdate::class),
+    ],
+    'step2' => [
+        Intent::make(NpmUpdateAndBuild::class),
+        Intent::make(MigrateDatabase::class),
+        Intent::make(SeedDatabase::class),
+        Intent::make(CacheApplication::class),
+        Intent::make(TerminateHorizon::class),
+        Intent::make(Pm2Restart::class),
+    ],
+],
+```
+
+Remove actions your application does not use. For example, remove `SeedDatabase`, `TerminateHorizon`, or `Pm2Restart`
+when those services are not part of the deployment. Arguments passed to `Intent::make()` are forwarded to the action's
+Artisan command.
+
+Set a stable bypass secret through configuration or ensure configuration is cached before deployment. Laravel uses
+this secret to let an operator bypass maintenance mode.
+
+### 2. Add the Inertia maintenance page
+
+Create the component configured by `deploy.inertia_component`, which defaults to:
+
+```text
+resources/js/Pages/Maintenance.vue
+```
+
+A minimal component might be:
+
+```vue
+<template>
+    <main>
+        <h1>We'll be right back</h1>
+        <p>The application is being updated. This page will refresh automatically.</p>
+    </main>
+</template>
+```
+
+The maintenance route uses `deploy.domain` and `deploy.path`. Make sure `APP_DOMAIN` contains a hostname such as
+`app.example.com`, not a URL with a scheme.
+
+### 3. Replace Laravel's maintenance middleware
+
+The package middleware allows the configured maintenance page to remain reachable while the application is down:
+
+```php
+use Illuminate\Foundation\Configuration\Middleware;
+use Laraveltoolkit\Deploy\PreventRequestsDuringMaintenance;
+
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->replace(
+        \Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
+        PreventRequestsDuringMaintenance::class,
+    );
+})
+```
+
+### 4. Enable live maintenance events (optional)
+
+When Laravel broadcasting and Echo are configured, the companion Vuetoolkit `Deploy()` helper listens on the public
+`deploy` channel. It reacts to `server_down` and `server_up` broadcasts so connected users can move to or leave the
+maintenance screen without waiting for their next request.
 
 ```js
-import Echo from "laravel-echo";
-import Pusher from "pusher-js";
-import { Deploy } from "laraveltoolkit";
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+import { Deploy } from 'laraveltoolkit';
 
 window.Pusher = Pusher;
-
 window.Echo = new Echo({
-    broadcaster: "reverb",
+    broadcaster: 'reverb',
     key: import.meta.env.VITE_REVERB_APP_KEY,
     wsHost: import.meta.env.VITE_REVERB_HOST,
     wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
     wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
-    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? "https") === "https",
-    enabledTransports: ["ws", "wss"],
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
 });
 
-Deploy(); // Register channels
+Deploy();
 ```
 
-Then you must to create `resources/js/Pages/Maintenance.vue` file to be the maintenance page
+This step is optional; normal Laravel maintenance redirects still work without broadcasting.
 
-After do this, replace the laravel `PreventRequestsDuringMaintenance` by version from this package
+## Running a deployment
 
-```php
-<?php
-
-use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Configuration\Exceptions;
-use Illuminate\Foundation\Configuration\Middleware;
-use Laraveltoolkit\Deploy\PreventRequestsDuringMaintenance;
-
-return Application::configure(basePath: dirname(__DIR__))
-    ->withRouting(
-        web: __DIR__.'/../routes/web.php',
-        commands: __DIR__.'/../routes/console.php',
-        channels: __DIR__.'/../routes/channels.php',
-        health: '/up',
-    )
-    ->withMiddleware(function (Middleware $middleware) {
-        $middleware
-            ->replace(
-                \Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance::class,
-                PreventRequestsDuringMaintenance::class
-            );
-
-        //
-    })
-    ->withExceptions(function (Exceptions $exceptions) {
-        //
-    })->create();
-
-```
-
-To use you must to call command:
+Start the interactive selector:
 
 ```bash
 php artisan deploy
 ```
 
-You can choice what action to run in deploy on laraveltoolkit configs
+Or invoke a stage directly:
+
+```bash
+php artisan deploy:1
+php artisan deploy:2
+```
+
+Stage 1 performs these operations:
+
+1. runs Laravel's `down` command with the configured bypass secret and maintenance redirect;
+2. broadcasts `MaintenanceEnabledEvent`;
+3. runs every `deploy.step1` intent;
+4. remembers stage 2 as the default selection for five minutes.
+
+Stage 2 runs every `deploy.step2` intent, calls Laravel's `up` command, and broadcasts
+`MaintenanceDisabledEvent`.
+
+> [!IMPORTANT]
+> Run stage 2 even when a stage 1 action fails, or bring the application up manually with `php artisan up`. The
+> built-in actions report command failures but do not guarantee an automatic rollback.
+
+## Built-in actions
+
+| Class | Internal signature | Behavior |
+|---|---|---|
+| `GitPull` | `git:pull` | Switches to a branch, pulls it, and optionally checks out the latest matching release tag. |
+| `ComposerUpdate` | `composer:update` | Runs `composer update`; adds optimized autoloading and `--no-dev` in production. |
+| `NpmUpdateAndBuild` | `npm:install` | Optionally runs `npm install` followed by `npm run build`. |
+| `MigrateDatabase` | `deploy:migrate` | Runs forced migrations. |
+| `SeedDatabase` | `deploy:seed` | Runs forced database seeders. |
+| `CacheApplication` | `deploy:cache` | Clears caches, then caches routes, config, events, and views in production. |
+| `TerminateHorizon` | `deploy:terminate_horizon` | Gracefully terminates Horizon workers. |
+| `Pm2Restart` | `pm2:restart` | Restarts all PM2 processes with updated environment variables. |
+
+Commands that execute in a working directory accept `--cwd`; pass it through the intent arguments when a frontend or
+repository lives outside Laravel's base path. Action commands are resolved by the deployment stages and are not
+registered as standalone Artisan commands by the package.
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/FILEPOND.md
+++ b/docs/FILEPOND.md
@@ -1,92 +1,146 @@
-### FilePond
+# FilePond uploads
 
-On vue, use the package component to help you use:
+The FilePond module stores browser uploads in a temporary filesystem location and returns a UUID to the form. Before
+validation, the request macro converts that UUID into a Laravel-compatible `UploadedFile`.
 
-```vue
-<template>
-    <form @submit.prevent="submit" class="w-full bg-white px-3 py-2 rounded shadow flex flex-col">
-        <Title>Upload test</Title>
-        <InputGroup :form="form" field="normal" label="Normal" v-slot="attrs">
-            <FilepondInput
-                :chunk="true"
-                :disabled="attrs.disabled"
-                :form="form"
-                :id="attrs.id"
-                v-model="form.normal"
-                :required="attrs.required"
-                :invalid="attrs.invalid"
-                :aria-describedby="attrs['aria-describedby']"/>
-        </InputGroup>
-    </form>
-</template>
+It supports normal uploads, chunked uploads, revert, restore, load, and remote fetch through package routes under
+`/lt/filepond`.
 
-<script lang="ts">
-import {defineComponent} from "vue";
-import {FilepondInput, InputGroup} from "laraveltoolkit";
-import {useForm} from "@inertiajs/vue3";
+## Setup
 
-export default defineComponent({
-    name: "UploadTest" ,
-    components: {
-        FilepondInput,
-        InputGroup,
-    },
-    data() {
-        return {
-            form: useForm({
-                normal: null,
-            }),
-        }
-    },
-    methods: {
-        submit(): void {
-            //submit
-        }
-    }
-});
-</script>
+Publish the package configuration:
+
+```bash
+php artisan vendor:publish --tag=laraveltoolkit-config
 ```
 
-Filepond will upload the file and put a uuid fot that file on input.
+Configure the temporary disk and path with environment variables:
 
-On request you must call `mergeFilepond` to convert the uploaded uuid into Uploaded file. After this you can validate it
-as a normal upload.
+```dotenv
+LT_FILEPOND_DISK=local
+LT_FILEPOND_ROOT_PATH=lt_filepond
+LT_FILEPOND_GC_PROBABILITY=0.1
+LT_FILEPOND_GC_UPLOAD_LIFE=86400
+LT_FILEPOND_GC_MAXIMUM_INTERACTIONS=100
+```
+
+The disk must provide a local path because the converted upload is backed by a filesystem file. Keep temporary
+uploads on a private disk; they are not permanent application assets.
+
+| Setting | Meaning |
+|---|---|
+| `disk` | Laravel filesystem disk used for temporary uploads. |
+| `root_path` | Base directory inside that disk. |
+| `garbage_collector.probability` | Chance from `0.0` to `1.0` that cleanup runs after an upload. |
+| `garbage_collector.upload_life` | Minimum age in seconds before a temporary upload may be removed. |
+| `garbage_collector.maximum_interactions` | Maximum entries processed by one cleanup run. |
+
+## Frontend
+
+The companion Vuetoolkit package provides a preconfigured `FilepondInput`:
+
+```vue
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { FilepondInput } from 'laraveltoolkit';
+
+const form = useForm<{ attachment: string | null }>({
+    attachment: null,
+});
+</script>
+
+<template>
+    <form @submit.prevent="form.post('/documents')">
+        <FilepondInput
+            id="attachment"
+            v-model="form.attachment"
+            :form="form"
+            :chunk="true"
+            required
+        />
+
+        <button type="submit" :disabled="form.processing">Save</button>
+    </form>
+</template>
+```
+
+After FilePond finishes uploading, `form.attachment` contains the temporary upload UUID, not the binary file.
+
+## Convert and validate the upload
+
+Call `mergeFilepond()` in `prepareForValidation()` so Laravel's file rules receive an uploaded file:
 
 ```php
-<?php
-
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Laraveltoolkit\Filepond\UploadedFile;
 
-/**
- * @property \Laraveltoolkit\Filepond\UploadedFile $normal
- */
-class FilepondRequest extends FormRequest
+/** @property-read UploadedFile|null $attachment */
+final class StoreDocumentRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     */
-    public function authorize(): bool
-    {
-        return true;
-    }
-
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
-     */
     public function rules(): array
     {
         return [
-            'normal' => 'required|extensions:zip',
+            'attachment' => ['required', 'file', 'mimes:pdf', 'max:10240'],
         ];
     }
 
-    public function prepareForValidation(): void
+    protected function prepareForValidation(): void
     {
-        $this->mergeFilepond('normal');
+        $this->mergeFilepond('attachment');
     }
 }
 ```
+
+You can also resolve the value without mutating the request:
+
+```php
+$file = $request->filepond('attachment');
+```
+
+Both methods return `null` when the identifier is absent, malformed, or does not point to exactly one temporary file.
+
+## Persisting the file
+
+After validation, treat the value like a Laravel uploaded file:
+
+```php
+$path = $request->attachment->store('documents', 'private');
+```
+
+Or assign it directly to a model field configured with a [Stored Assets recipe](STORED_ASSETS.md).
+
+Temporary data is deleted after the request when validation did not place errors in the session. Persist or move the
+file during the request; do not keep the temporary UUID as your application's permanent file reference.
+
+## Routes
+
+The service provider registers these named routes with Laravel's `web` middleware:
+
+| Method | Path | Route name |
+|---|---|---|
+| `POST` | `/lt/filepond/process` | `lt.filepond.process` |
+| `PATCH` | `/lt/filepond/process-chunk` | `lt.filepond.process_chunk` |
+| `DELETE` | `/lt/filepond/revert` | `lt.filepond.revert` |
+| `GET` | `/lt/filepond/load` | `lt.filepond.load` |
+| `GET` | `/lt/filepond/restore` | `lt.filepond.restore` |
+| `GET` | `/lt/filepond/fetch` | `lt.filepond.fetch` |
+
+> [!CAUTION]
+> The `load` and `fetch` endpoints retrieve a URL supplied by the client. Do not expose remote-file loading to
+> untrusted users unless your application validates destinations or restricts access at the web server/application
+> boundary. This avoids turning the endpoint into a server-side request forgery surface.
+
+## Troubleshooting
+
+- If conversion returns `null`, confirm the submitted value is the UUID returned by the process endpoint and that the
+  temporary directory contains exactly one completed file.
+- If chunked uploads never complete, verify that the proxy forwards the `Upload-Length`, `Upload-Offset`, and
+  `Upload-Name` headers and permits `PATCH` requests.
+- If file validation reports an unreadable upload, use a local-compatible filesystem disk and confirm the PHP process
+  can read and rename its files.
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/FLASH.md
+++ b/docs/FLASH.md
@@ -1,64 +1,111 @@
-### Flash
+# Flash messages
 
-Flash help you send messages for UI.
+The Flash module sends structured messages through Inertia's flash data. The companion Vuetoolkit receiver turns
+them into PrimeVue toasts after a redirect or Inertia response.
+
+## Sending messages
+
+```php
+use Laraveltoolkit\Facades\Flash;
+
+Flash::success('User saved.');
+Flash::info('The import is still running.');
+Flash::warn('Your subscription expires soon.');
+Flash::error('The report could not be generated.');
+Flash::secondary('A neutral update.');
+Flash::contrast('An emphasized update.');
+```
+
+The first argument is the detail. The optional second argument is a summary:
+
+```php
+Flash::success('The profile changes are now active.', 'Profile saved');
+```
+
+Messages are chainable:
+
+```php
+Flash::success('User saved.')
+    ->closable()
+    ->withLife(4_000)
+    ->withGroup('account');
+
+Flash::error('Connection lost.')->unclosable();
+```
+
+`life` follows PrimeVue and is expressed in milliseconds.
+
+## Defaults
+
+Publish the package configuration to set defaults for every message:
+
+```bash
+php artisan vendor:publish --tag=laraveltoolkit-config
+```
+
+```php
+'flash' => [
+    'defaults' => [
+        'closable' => null,
+        'life' => null,
+        'group' => 'lt-default',
+    ],
+],
+```
+
+A `null` option is omitted from the flash payload and lets PrimeVue apply its own default. Chain methods override the
+configured value for one message.
+
+## PrimeVue receiver
+
+First install and configure PrimeVue's Toast service as described in the
+[PrimeVue Toast documentation](https://primevue.org/toast/). Mount one `Toast` for each group you use, then initialize
+Vuetoolkit's receiver once in a persistent layout:
+
+```vue
+<script lang="ts">
+import { defineComponent } from 'vue';
+import Toast from 'primevue/toast';
+import { ToastReceiver } from 'laraveltoolkit';
+
+export default defineComponent({
+    components: { Toast },
+    created() {
+        ToastReceiver(this.$toast);
+    },
+});
+</script>
+
+<template>
+    <Toast group="lt-default" />
+    <Toast group="account" />
+    <slot />
+</template>
+```
+
+Keep the receiver in a layout that is not repeatedly mounted during normal Inertia navigation; otherwise the same
+message may be handled more than once.
+
+## Testing
+
+The facade includes PHPUnit/Pest-compatible assertions:
 
 ```php
 use Laraveltoolkit\Facades\Flash;
 use Laraveltoolkit\Flash\Severity;
 
-// You can use this severities
-Flash::success('Success Test');
-Flash::info('Info Test');
-Flash::warn('Warn Test');
-Flash::error('Error Test');
-Flash::secondary('Secondary Test');
-Flash::contrast('Contrast Test');
+Flash::assertFlashed();
+Flash::assertFlashed(Severity::SUCCESS);
+Flash::assertFlashed(Severity::SUCCESS, 'User saved.');
+Flash::assertFlashed(Severity::SUCCESS, 2);
 
-// You can pass a summary
-Flash::success('Message detail', 'Success!');
-
-// You can mark flash as closable or unclosable
-Flash::success('Success Test closable')->closable();
-Flash::success('Success Test unclosable')->unclosable();
-
-// You can pass a lifetime in seconds to your flash
-Flash::success('Success Test with life')->withLife(2000);
-
-// Your message can belong to another group (renders in another primevue group)
-Flash::success('Success Test in other group')->withGroup('foo_bar');
-
-// You can test flash using
- Flash::assertFlashed(Severity::SUCCESS, 'User saved!');
- Flash::assertNotFlashed(Severity::SUCCESS, 'User saved!');
+Flash::assertNotFlashed();
+Flash::assertNotFlashed(Severity::ERROR);
 ```
 
-You must first configure primevue Toast service following [this guide](https://primevue.org/toast/) and then put
-`ToastReceiver`
-Composable on created Vue method to init it.
+The second `assertFlashed()` argument matches an exact detail when it is a string, or an exact message count when it
+is an integer.
 
-```vue
+---
 
-<template>
-    <div>
-        <!-- lt-default is de default group -->
-        <Toast group="lt-default"/>
-        <slot/>
-    </div>
-</template>
-
-<script lang="ts">
-    import {defineComponent} from "vue";
-    import {ToastReceiver} from 'laraveltoolkit';
-    import {Toast} from 'primevue';
-
-    export default defineComponent({
-        name: "Flash",
-        components: {
-            Toast,
-        },
-        created() {
-            ToastReceiver(this.$toast)
-        },
-    });
-</script>
-```
+[Back to the documentation index](README.md)

--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -3,6 +3,9 @@
 Measurement provides immutable-style value objects for typed measurements. Length, weight, volume, area, temperature,
 speed, duration, pressure, energy, and power are currently supported.
 
+The feature requires PHP's BCMath and Intl extensions. All measurement helpers are loaded automatically after Composer
+installs the package.
+
 ```php
 use Laraveltoolkit\Measurement\Enums\AreaUnit;
 use Laraveltoolkit\Measurement\Enums\DurationUnit;
@@ -332,3 +335,7 @@ length(2, 'nm')->div(3)->referenceValueString();
 length(2, 'nm')->div(3, RoundingMode::TowardsZero)->referenceValueString();
 // 0.666666666666666666666666
 ```
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/MULTI_DOMAIN.md
+++ b/docs/MULTI_DOMAIN.md
@@ -1,89 +1,102 @@
-## Multi Domain application
+# Multi-domain Inertia visits
 
-### 1. Publishing Laravel CORS config file
+Browsers cannot complete a normal Inertia XHR visit when navigation crosses hostnames. The
+`HandleInertiaCrossDomainVisits` middleware detects an Inertia `GET` request whose host differs from the previous URL
+and returns `Inertia::location()`, forcing a full browser visit to the destination.
 
-if you don't have the Laravel cors config, then publish it using:
+Use this guide only when one Laravel application serves multiple trusted domains or subdomains.
+
+## 1. Publish Laravel's CORS configuration
+
+If `config/cors.php` does not exist:
 
 ```bash
 php artisan config:publish cors
 ```
 
-### 2. Editing the CORS config file
+## 2. Allow the trusted application origins
 
-On config file edit the follow lines:
+Make sure the routes involved in navigation are covered and expose Inertia's response headers:
 
 ```php
-<?php
-
 return [
-    // Replace this:
-    'paths' => ['api/*', 'sanctum/csrf-cookie'],
-    // By this 
     'paths' => ['*'],
 
     'allowed_methods' => ['*'],
 
-    // Here allow only origins that um trust
     'allowed_origins' => [
         env('APP_URL', 'http://localhost'),
-        // ...
+        env('ADMIN_URL', 'http://admin.localhost'),
     ],
 
     'allowed_origins_patterns' => [],
-
     'allowed_headers' => ['*'],
 
-    // Replace this:
-    'exposed_headers' => [], 
-     // By this 
-    'exposed_headers' => ['x-inertia', 'x-inertia-location'],
+    'exposed_headers' => [
+        'x-inertia',
+        'x-inertia-location',
+    ],
 
     'max_age' => 0,
-
     'supports_credentials' => false,
-
 ];
 ```
 
-### 3. Add middleware
+> [!CAUTION]
+> List exact trusted origins. Do not combine wildcard origins with credentialed requests. If the domains must share
+> an authenticated session, configure Laravel's session cookie domain, Sanctum/stateful domains where applicable,
+> frontend credentials, and `supports_credentials` as a coordinated security decision.
 
-You will need a middleware that changes a default redirect or visit by the `Inertia::location()` when needed.
+Narrow `paths` and `allowed_methods` when your routing structure allows it; the broad values above support navigation
+across all web routes.
 
-On your `bootstrap/app.php` file prepend the `Laraveltoolkit\Inertia\HandleInertiaCrossDomainVisits` middleware:
+## 3. Prepend the middleware
+
+In `bootstrap/app.php`, run the package middleware before the rest of the `web` stack:
 
 ```php
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+use Laraveltoolkit\Inertia\HandleInertiaCrossDomainVisits;
+
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
-        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
-        channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->web(
-            append: [
-                HandleInertiaRequests::class,
-                AddLinkHeadersForPreloadedAssets::class,
-            ],
             prepend: [
                 HandleInertiaCrossDomainVisits::class,
-            ]);
+            ],
+        );
     })
-    ->withExceptions(function (Exceptions $exceptions) {
-        //
-    })->create();
+    ->create();
 ```
 
-### 4. NGINX
+The middleware leaves non-Inertia requests, non-`GET` requests, and same-host visits unchanged.
 
-If you are using NGINX as your server, it will manage yours `OPTIONS` request, so, they will not processed by Laravel Cors. To Avoid this add this snipped to you site configuration:
+## 4. Forward preflight requests through Nginx when needed
+
+Some Nginx configurations answer `OPTIONS` before Laravel can add CORS headers. If that applies to your server,
+forward preflight requests to the front controller:
 
 ```nginx
-    if ($request_method = OPTIONS) {
-        rewrite ^ /index.php last;
-    }
+if ($request_method = OPTIONS) {
+    rewrite ^ /index.php last;
+}
 ```
 
+Prefer configuring CORS in one layer only. If Nginx already returns the complete, correct CORS response, Laravel does
+not need to process the preflight.
 
+## Verify the integration
 
+From one configured origin, trigger an Inertia link to the other host and inspect the browser network panel. The
+cross-host request should return an Inertia location response, after which the browser performs a full document
+navigation. Same-host links should remain normal client-side Inertia visits.
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/PRIMEVUE_DATA.md
+++ b/docs/PRIMEVUE_DATA.md
@@ -1,281 +1,262 @@
-## PrimeVue Data
+# PrimeVue Data
 
-A minimalist implementation of DataTables and DataView on Laravel
+PrimeVue Data connects Eloquent pagination to the companion Vuetoolkit `DataTableAdapter` and `DataViewAdapter`.
+Frontend pagination, sorting, and filter state are posted through Inertia; the backend `primevueData()` macro applies
+them to the query and returns a standard Laravel paginator with its page name included.
 
-### Frontend (Laravel)
+## Backend setup
 
-On laravel, basically, you need to do only two tings.
+### Accept `GET` and `POST`
 
-#### Change route method
-
-```php
-// From this
-Route::get('/', Controller::class);
-
-// To this
-Route::getAndPost('/', Controller::class);
-```
-
-> To avoid polluting the URLs with search and sorting parameters, we send the parameters via post in the Inertia`reload`
-> method.
-
-#### Config action `data` prop
+The adapters use `POST` for partial reloads so table state does not fill the URL query string. Register the route with
+the package macro:
 
 ```php
-use \App\Models\User;
-use \Inertia\Inertia;
+use Illuminate\Support\Facades\Route;
 
-Inertia::render('Users', [
-    'users' => fn() => User::query()->primevueData(),
-])
+Route::getAndPost('/users', UsersController::class)
+    ->name('users.index');
 ```
 
-> This way, the data from the current pagination page will be loaded together with the first load.
+This registers `HEAD`, `GET`, and `POST` for the same action. Apply the same authentication, authorization, and rate
+limiting middleware you would use for a normal data endpoint.
 
-With Lazy load:
+### Return paginated data
 
 ```php
-use \App\Models\User;
-use \Inertia\Inertia;
+use App\Models\User;
+use Inertia\Inertia;
 
-Inertia::render('Users', [
-    'users' => Inertia::lazy(fn() => User::query()->primevueData()),
-])
+return Inertia::render('Users/Index', [
+    'users' => fn () => User::query()->primevueData(),
+]);
 ```
 
-> Here, the main page is loaded first, and only then does it load the table data automatically.
-
-With two `data`:
+The builder macro accepts three arguments:
 
 ```php
-use \App\Models\User;
-use \Inertia\Inertia;
-
-Inertia::render('Users', [
-    'users' => Inertia::lazy(fn() => User::query()->primevueData()),
-    'categories' => Inertia::lazy(fn() => Categories::query()->primevueData('page_categories')),
-])
+primevueData(
+    pageName: 'page',
+    globalFilterColumns: null,
+    mapOrResource: null,
+)
 ```
 
-> If you do not change the `pageName` attribute when using more than one `data`, some unexpected behavior may occur.
+- `pageName` isolates pagination and adapter options. Use a unique value for each dataset on a page.
+- `globalFilterColumns` limits the columns searched by the global filter. When `null`, all model table columns are
+  discovered through the schema.
+- `mapOrResource` transforms page items with a closure or a Laravel JSON resource class.
 
-With custom global `$globalFilterColumn` attribute:
+An explicit global search list is usually faster and avoids searching sensitive or unsuitable columns:
 
 ```php
-use \App\Models\User;
-use \Inertia\Inertia;
-
-Inertia::render('Users', [
-    'users' => Inertia::lazy(fn() => User::query()->primevueData(globalFilterColumn: 'foo')),
-])
+'users' => fn () => User::query()->primevueData(
+    globalFilterColumns: ['name', 'email'],
+),
 ```
 
-> In some scenarios, such as when the database table in question has a column called `global`, it may be necessary to
-> change this attribute so that it is possible to search all columns in the table.
+Transform results without losing paginator metadata:
 
-### Frontend (PrimeVue)
+```php
+use App\Http\Resources\UserResource;
+
+'users' => fn () => User::query()->primevueData(
+    mapOrResource: UserResource::class,
+),
+```
+
+### Deferred data
+
+Use an Inertia deferred prop when the page shell should render before the query:
+
+```php
+'users' => Inertia::defer(
+    fn () => User::query()->primevueData(),
+),
+```
+
+For two adapters, give each one a distinct prop and page name:
+
+```php
+return Inertia::render('Dashboard', [
+    'users' => Inertia::defer(
+        fn () => User::query()->primevueData(pageName: 'users_page'),
+    ),
+    'categories' => Inertia::defer(
+        fn () => Category::query()->primevueData(pageName: 'categories_page'),
+    ),
+]);
+```
+
+## Supported filters
+
+The backend understands PrimeVue filter operators `and` and `or`, plus these match modes:
+
+| Match mode | Behavior |
+|---|---|
+| `startsWith` | Case-insensitive text prefix. |
+| `contains` | Case-insensitive text search. |
+| `notContains` | Case-insensitive negative text search. |
+| `endsWith` | Case-insensitive text suffix. |
+| `equals` | Database equality. |
+| `notEquals` | Database inequality. |
+
+Empty constraints and unknown match modes are ignored. Global filtering uses the first valid global constraint and
+joins the configured columns with `OR`.
 
 ## DataTable
 
-An example of how use with DataTable.
-
-Some points of `attention` are:
-
-- Remember to put lazy prop on DataTable.
-- You must create filter data prop to use the filters function. Remember to pass it on DataTable.
-
-Available adapter props:
-
-- **manualFilterDebounceWait**: How many milliseconds filter will debounce before do it.
-- **globalFilterName**: Here you configure if needed the global filter key. On this filter, it will search all (or
-  configured in Laravel
-- **propName (required)**: Prop that will be load. Configured by you on Inertia props on Laravel. Eg.: users.
-- **rows**: How many rows per page adapter will get.
-- **preserveState**: If true, will preserve sort, filter and page state.
-
-> If you want to use preserveState, you must set `first`, `sortField` and `sortOrder` like bellow to work correctly.
+Create the PrimeVue filter state, then connect every adapter callback and value to the matching table prop:
 
 ```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import Button from 'primevue/button';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+import { FilterMatchMode, FilterOperator } from '@primevue/core/api';
+import { DataTableAdapter } from 'laraveltoolkit';
+
+const filters = ref({
+    global: {
+        operator: FilterOperator.AND,
+        constraints: [{ value: '', matchMode: FilterMatchMode.CONTAINS }],
+    },
+    name: {
+        operator: FilterOperator.AND,
+        constraints: [{ value: '', matchMode: FilterMatchMode.CONTAINS }],
+    },
+    email: {
+        operator: FilterOperator.AND,
+        constraints: [{ value: '', matchMode: FilterMatchMode.CONTAINS }],
+    },
+});
+</script>
 
 <template>
-    <DataTableAdapter prop-name="users" v-slot="props" :rows="15" :filters="filters">
-        <Button label="Clear" @click="props.clearFilters" />
-        <input v-model="filters.global.constraints[0].value" @keyup="props.manualFilter(filters)">
+    <DataTableAdapter
+        v-slot="table"
+        prop-name="users"
+        :rows="15"
+        :filters="filters"
+        :preserve-state="true"
+    >
+        <div>
+            <input
+                v-model="filters.global.constraints[0].value"
+                type="search"
+                @input="table.manualFilter(filters)"
+            >
+            <Button label="Clear filters" @click="table.clearFilters" />
+        </div>
+
         <DataTable
-            :first="props.first"
-            :sort-field="props.currentSort[0]?.field"
-            :sort-order="props.currentSort[0]?.order"
+            v-model:filters="filters"
+            data-key="id"
+            filter-display="menu"
+            lazy
+            paginator
             removable-sort
             sort-mode="multiple"
-            data-key="id"
-            @page="props.page"
-            @filter="props.filter"
-            filter-display="menu"
-            @sort="props.sort"
-            v-model:filters="filters"
-            :loading="props.loading"
-            lazy
-            :rows="props.rows"
-            paginator
-            :total-records="props.total"
-            :value="props.value">
-            <Column field="id" :sortable="true" header="Id">
-                <template #filter="{filterModel, filterCallback}">
-                    <input v-model="filterModel.value" type="text" @input="filterCallback()" class="p-column-filter"
-                           placeholder="Search by country" />
+            :first="table.first"
+            :loading="table.loading"
+            :rows="table.rows"
+            :sort-field="table.currentSort[0]?.field"
+            :sort-order="table.currentSort[0]?.order"
+            :total-records="table.total"
+            :value="table.value"
+            @filter="table.filter"
+            @page="table.page"
+            @sort="table.sort"
+        >
+            <Column field="id" header="ID" sortable />
+            <Column field="name" header="Name" sortable>
+                <template #filter="{ filterModel, filterCallback }">
+                    <input v-model="filterModel.value" @input="filterCallback()">
                 </template>
             </Column>
-            <Column field="name" :sortable="true" header="Nome">
-                <template #filter="{filterModel, filterCallback}">
-                    <input v-model="filterModel.value" type="text" @input="filterCallback()" class="p-column-filter"
-                           placeholder="Search by country" />
-                </template>
-            </Column>
-            <Column field="email" :sortable="true" header="Email" />
+            <Column field="email" header="Email" sortable />
         </DataTable>
     </DataTableAdapter>
 </template>
-
-<script lang="ts">
-    import { defineComponent } from "vue";
-    import { DataTableAdapter } from "laraveltoolkit";
-    import DataTable from "primevue/datatable";
-    import Column from "primevue/column";
-    import Button from "primevue/button";
-    import { FilterMatchMode, FilterOperator } from '@primevue/core/api';
-
-    export default defineComponent({
-        name: "TableAdapter",
-        components: {
-            Button,
-            DataTableAdapter,
-            DataTable,
-            Column
-        },
-        data() {
-            return {
-                filters: {
-                    global: { operator: FilterOperator.AND, constraints: [{ value: '', matchMode: 'contains' }] },
-                    id: {
-                        operator: FilterOperator.AND,
-                        constraints: [{ value: '', matchMode: FilterMatchMode.CONTAINS }]
-                    },
-                    name: {
-                        operator: FilterOperator.AND,
-                        constraints: [{ value: '', matchMode: FilterMatchMode.CONTAINS }]
-                    },
-                },
-            }
-        },
-    });
-</script>
 ```
 
-> Some props are required that you pass to `DataTable` to get all features from adapter.
->
-> - **page**: You must pass to `@page` event to handle page changes.
-> - **sort**: You must pass to `@sort` event to handle sort changes.
-> - **filter**: You must pass to `@filter` event to handle filter changes.
-> - **loading**: You must pass to `loading` prop to handle loading fallback.
-> - **rows**: You must pass to `rows` prop to work.
-> - **total**: You must pass to `total-records` prop to work.
-> - **value**: You must pass to `value` prop to work.
+Required connections are `@page`, `@sort`, `@filter`, `loading`, `rows`, `total-records`, and `value`. When preserving
+state, also connect `first`, `sort-field`, and `sort-order` as shown.
+
+Useful adapter props:
+
+| Prop | Purpose |
+|---|---|
+| `propName` | Required Inertia prop containing the paginator. |
+| `rows` | Records requested per page. |
+| `filters` | PrimeVue filter state. |
+| `manualFilterDebounceWait` | Debounce delay for `manualFilter()`. |
+| `globalFilterName` | Key used for the global filter; defaults to `global`. |
+| `preserveState` | Preserves page, sorting, and filters across visits. |
 
 ## DataView
 
-An example of how use with DataView.
-
-Some points of `attention` are:
-
-- Remember to put lazy prop on DataView.
-- You must create filter data prop to use the filters function. Remember to pass it on DataViewAdapter and DataView.
-
-Available adapter props:
-
-- **filters**: Here you will pass your filters like you pass to DataView.
-- **filterDebounceWait**: How many milliseconds filter will debounce before do it.
-- **globalFilterName**: Here you configure if needed the global filter key. On this filter, it will search all (or
-  configured in Laravel
-- **propName (required)**: Prop that will be load. Configured by you on Inertia props on Laravel. Eg.: users.
-- **rows**: How many rows per page adapter will get.
-- **sortField**: Table field that will be sorted.
-- **sortOrder**: Sort direction (asc or desc).
+`DataViewAdapter` uses the same backend response and a smaller set of bindings:
 
 ```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import DataView from 'primevue/dataview';
+import { DataViewAdapter } from 'laraveltoolkit';
+
+const filters = ref({
+    global: { value: '', matchMode: 'contains' },
+});
+</script>
 
 <template>
-    <DataViewAdapter prop-name="users" v-slot="props" :rows="5" :filters="filters">
-        <Button label="Clear" @click="props.clearFilters" />
-        <input v-model="filters.global.value">
+    <DataViewAdapter
+        v-slot="view"
+        prop-name="users"
+        :rows="12"
+        :filters="filters"
+    >
+        <input v-model="filters.global.value" type="search">
+
         <DataView
             data-key="id"
-            @page="props.page"
             lazy
-            :rows="props.rows"
             paginator
-            :total-records="props.total"
-            :value="props.value">
-            <template #list="slotProps">
-                <div class="flex flex-col">
-                    <div v-for="(item, index) in slotProps.items" :key="index">
-                        <div class="flex flex-col sm:flex-row sm:items-center p-6 gap-4"
-                             :class="{ 'border-t border-surface-200 dark:border-surface-700': index !== 0 }">
-                            <div class="flex flex-col md:flex-row justify-between md:items-center flex-1 gap-6">
-                                <div class="flex flex-row md:flex-col justify-between items-start gap-2">
-                                    <div>
-                                        <span class="font-medium text-surface-500 dark:text-surface-400 text-sm">{{ item.category }}</span>
-                                        <div class="text-lg font-medium mt-2">{{ item.name }}</div>
-                                    </div>
-                                    <div class="bg-surface-100 p-1" style="border-radius: 30px">
-                                        <div class="bg-surface-0 flex items-center gap-2 justify-center py-1 px-2">
-                                            <span class="text-surface-900 font-medium text-sm">{{ item.email }}</span>
-                                            <i class="pi pi-star-fill text-yellow-500"></i>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="flex flex-col md:items-end gap-8">
-                                    <span class="text-xl font-semibold">{{ item.id }}</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            :rows="view.rows"
+            :total-records="view.total"
+            :value="view.value"
+            @page="view.page"
+        >
+            <template #list="{ items }">
+                <article v-for="user in items" :key="user.id">
+                    <strong>{{ user.name }}</strong>
+                    <span>{{ user.email }}</span>
+                </article>
             </template>
         </DataView>
     </DataViewAdapter>
 </template>
-
-<script lang="ts">
-    import { defineComponent } from "vue";
-    import { DataViewAdapter } from "laraveltoolkit";
-    import DataView from "primevue/dataview";
-    import Button from "primevue/button";
-
-    export default defineComponent({
-        name: "ViewAdapter",
-        components: {
-            Button,
-            DataViewAdapter,
-            DataView,
-        },
-        data() {
-            return {
-                filters: {
-                    global: { value: '', matchMode: 'contains' },
-                    id: { value: '', matchMode: 'contains' },
-                    name: { value: '', matchMode: 'contains' }
-                },
-            }
-        },
-        mounted() {
-        }
-    });
-</script>
 ```
 
-> Some props are required that you pass to `DataView` to get all features from adapter.
->
-> - **page**: You must pass to `@page` event to handle page changes.
-> - **rows**: You must pass to `rows` prop to work.
-> - **total**: You must pass to `total-records` prop to work.
-> - **value**: You must pass to `value` prop to work.
+The required DataView connections are `@page`, `rows`, `total-records`, and `value`. Adapter props also support
+`filterDebounceWait`, `globalFilterName`, `sortField`, and `sortOrder`.
+
+## Joins and aliases
+
+For joined queries, select every filterable/sortable column explicitly and alias computed fields. The backend maps a
+frontend field to a selected qualified column or alias where possible:
+
+```php
+Product::query()
+    ->select('products.*', 'users.name as user_name')
+    ->join('users', 'users.id', '=', 'products.user_id')
+    ->primevueData(globalFilterColumns: ['products.name', 'users.name']);
+```
+
+Keep adapter field names controlled by your own component definitions. Do not pass arbitrary user-provided field
+names into query construction outside the adapter contract.
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,45 @@
+# Documentation
+
+Laravel Toolkit is modular: install the package once, then configure only the features your application uses.
+
+## Choose a feature
+
+| Guide | Use it when you need |
+|---|---|
+| [Measurement](MEASUREMENT.md) | Typed values, unit conversion, localized formatting, arithmetic, or Eloquent measurement casts. |
+| [ACL](ACL.md) | Policies, rules, roles, Laravel Gate abilities, or role middleware. |
+| [Stored Assets](STORED_ASSETS.md) | Durable file storage tied to Eloquent models, including variants and cleanup. |
+| [Utilities](UTILITIES.md) | Validation rules, document/phone helpers, regex utilities, enums, or Laravel macros. |
+| [PrimeVue Data](PRIMEVUE_DATA.md) | Server-side PrimeVue DataTable or DataView filtering, sorting, and pagination. |
+| [FilePond](FILEPOND.md) | Temporary or chunked browser uploads. |
+| [Flash](FLASH.md) | Backend session messages displayed as PrimeVue toasts. |
+| [SEO](SEO.md) | HTML metadata, Open Graph, Twitter cards, robots directives, or `robots.txt`. |
+| [Sitemap](SITEMAP.md) | XML sitemaps, sitemap indexes, domain-specific URLs, or large query sets. |
+| [Deploy](DEPLOY.md) | Two-stage deployments and an Inertia-aware maintenance screen. |
+| [Multi-domain Inertia](MULTI_DOMAIN.md) | Inertia visits that can redirect between trusted application domains. |
+
+## Common setup commands
+
+```bash
+# Package configuration
+php artisan vendor:publish --tag=laraveltoolkit-config
+
+# ACL and Stored Assets tables
+php artisan vendor:publish --tag=laraveltoolkit-migrations
+php artisan migrate
+
+# Editable sitemap registration file
+php artisan vendor:publish --tag=laraveltoolkit-sitemap
+```
+
+The package service provider is discovered automatically. You only need to register feature-specific application
+code described in each guide.
+
+## Frontend companion
+
+Guides that import components from `laraveltoolkit` in Vue refer to the
+[Vuetoolkit](https://github.com/wsssoftware/vuetoolkit) npm package. Laravel Toolkit 3.x is paired with Vuetoolkit 2.x.
+
+---
+
+[Back to the project README](../README.md)

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -1,125 +1,180 @@
-### SEO
+# SEO metadata and robots
 
-Provide an easy way to use SEO on your application.
+The SEO module builds one request-scoped metadata payload for Blade and Inertia. It supports titles, descriptions,
+canonical URLs, robots directives, Open Graph, Twitter cards, crawler detection, friendly URLs, and dynamic
+`robots.txt` output.
+
+## Configure metadata
+
+Set metadata before returning the response, usually in a controller:
 
 ```php
-use Illuminate\Http\Request;
-use Inertia\Response;
+use Inertia\Inertia;
 use Laraveltoolkit\Facades\SEO;
 use Laraveltoolkit\SEO\Image;
+use Laraveltoolkit\SEO\RobotRule;
 
-class ExampleController
+public function __invoke()
 {
-    /**
-     * Handle the incoming request.
-     */
-    public function __invoke(Request $request): Response
-    {
-        SEO::withTitle('Client Orders')
-            ->withoutDescription('A long description of this page')
-            ->withCanonical('https://foo.com')
-            ->withOpenGraphImage(new Image('public', 'seo.webp'))
-            ->withTwitterCardImage(new Image('public', 'seo.webp', 'alt title'));
-            
-        // If you want to remove a property you can call methods prefixed with `without`
-        SEO::withoutOpenGraphImage();
-            
-        return Inertia::render('Example');
-    }
+    SEO::withTitle('Client orders')
+        ->withDescription('Review and manage client orders.')
+        ->withCanonical(route('orders.index'))
+        ->withRobots(RobotRule::ALL)
+        ->withOpenGraphType('website')
+        ->withOpenGraphImage(new Image('public', 'seo/orders.webp', 'Orders dashboard'))
+        ->withTwitterCardSite('@example')
+        ->withTwitterCardImage(new Image('public', 'seo/orders.webp', 'Orders dashboard'));
+
+    return Inertia::render('Orders/Index');
 }
 ```
 
-On Inertia (If you use) middleware put:
+Images are resolved through the configured Laravel filesystem disk. Their URL receives the file's last-modified value
+as a cache-busting query string when available.
+
+## Metadata propagation
+
+Propagation is enabled by default. Changing the main title, description, or canonical URL also updates matching Open
+Graph and Twitter values:
 
 ```php
-//...
-public function share(Request $request): array
-    {
-        return [
-            //...
-            'seo' => fn() => SEO::payload(),
-        ];
-    }
-//...
+SEO::withTitle('Orders');
+// Also sets Open Graph and Twitter titles.
+
+SEO::withTitle('Orders', propagate: false);
+// Changes only the main title.
+
+SEO::withoutPropagation()
+    ->withTitle('Orders');
 ```
 
-On your views vue `seo` blade component to this works on non JS crawlers
+Use the specific methods when networks need different content:
 
-```bladehtml
+```php
+SEO::withOpenGraphTitle('Orders on Example')
+    ->withOpenGraphDescription('Browse the latest orders.')
+    ->withOpenGraphUrl(route('orders.index'))
+    ->withTwitterCardTitle('Latest orders')
+    ->withTwitterCardDescription('Browse them on Example.');
+```
+
+Every `with...` method has a corresponding `without...` method for optional values, for example
+`withoutTitle()`, `withoutCanonical()`, and `withoutOpenGraphImage()`.
+
+When no canonical URL or Open Graph URL is configured, the payload uses the current request URL. Calling
+`withoutCanonical()` explicitly suppresses the canonical link.
+
+## Server-rendered tags
+
+Add the Blade component to the document `<head>` so crawlers receive metadata in the initial HTML:
+
+```blade
 <head>
-    ...
-    <x-seo/>
-    ...
+    <!-- ... -->
+    <x-seo />
 </head>
 ```
 
-On your Vue layout load Head component to update head properties when navigate between pages.
+The component is registered automatically and renders the package's SEO view.
+
+## Inertia and Vue
+
+Share the payload from `HandleInertiaRequests`:
+
+```php
+use Illuminate\Http\Request;
+use Laraveltoolkit\Facades\SEO;
+
+public function share(Request $request): array
+{
+    return [
+        ...parent::share($request),
+        'seo' => fn () => SEO::payload(),
+    ];
+}
+```
+
+Then render Vuetoolkit's `Head` component once in the application layout so metadata follows client-side navigation:
 
 ```vue
-<template>
-    <div>
-        <Head/>
-    </div>
-</template>
-
-<script lang="ts">
-    import {defineComponent} from "vue";
-    import {Head} from "laraveltoolkit";
-
-    export default defineComponent({
-        name: "TestLayout",
-        components: {
-            Head,
-        }
-    });
+<script setup lang="ts">
+import { Head } from 'laraveltoolkit';
 </script>
+
+<template>
+    <Head />
+    <slot />
+</template>
 ```
 
-SEO facade also provide some utils methods
+The Blade and Vue renderers are complementary: Blade covers the initial response and non-JavaScript crawlers, while
+Vue updates metadata during Inertia visits.
+
+## Robots meta directives
+
+Pass enum values or directive strings:
 
 ```php
-use Laraveltoolkit\Facades\SEO;
+use Laraveltoolkit\SEO\RobotRule;
 
-// Returns true if request agent is a crawler
+SEO::withRobots(
+    RobotRule::NOINDEX,
+    RobotRule::NOFOLLOW,
+    'max-snippet:120',
+);
+
+SEO::withoutRobots();
+```
+
+Supported enum cases include `ALL`, `NOINDEX`, `NOFOLLOW`, `NONE`, `NOARCHIVE`, `NOSNIPPET`, `NOIMAGEINDEX`,
+`NOTRANSLATE`, `INDEXIFEMBEDDED`, `MAX_SNIPPET`, `MAX_IMAGE_PREVIEW`, `MAX_VIDEO_PREVIEW`, and
+`UNAVAILABLE_AFTER`.
+
+## `robots.txt`
+
+When default sitemap routes are enabled, the package also registers `/robots.txt`. Its behavior is:
+
+1. `public/robots.txt` wins because the web server normally serves it before Laravel;
+2. when `public/robots.stub` exists, Laravel returns its contents and appends the configured sitemap URL;
+3. otherwise, Laravel generates the file from SEO configuration and request-time rules.
+
+Configure generated rules in `config/laraveltoolkit.php` or at runtime:
+
+```php
+SEO::withRobotsTxtRule(
+    userAgent: '*',
+    allow: collect(['/']),
+    disallow: collect(['/admin', '/account']),
+);
+
+SEO::withRobotsTxtSitemap(route('lt.sitemap'));
+
+SEO::withoutRobotsTxtRule('Googlebot');
+SEO::withoutRobotsTxtRule(); // Remove every user-agent rule.
+SEO::withoutRobotsTxtSitemap(); // Restore the default sitemap route when available.
+```
+
+For sitemap registration and indexes, see the [Sitemap guide](SITEMAP.md).
+
+## Utilities
+
+```php
 SEO::isCrawler();
-// or
-SEO::isCrawler('user agent');
+SEO::isCrawler($request->userAgent());
 
-// Transform a human string into a pretty wrote url string
-SEO::friendlyUrlString('A example of string!')
-// returns 'a-example-of-string'
+SEO::friendlyUrlString('An example string!');
+// an-example-string
+
+SEO::friendlyUrlString('R&D @ Example', separator: '_', language: 'en');
 ```
 
-In conjunction with the [Sitemap](SITEMAP.md) helpers, you can use the SEO facade to generate your Robots.txt.
+Friendly URL behavior can be customized under `seo.friendly_url` in the package configuration.
 
-There are 3 possibilities:
+## Defaults
 
-1. Keep your `robots.txt` in the public folder, nothing will happen.
-2. Change its name to `robots.stub`, so, the Sitemap helper will take the stub content and add the sitemap url every
-   time the user accesses https://foobar.com/robots.txt.
-3. Or finally, you can simply remove it and then and SEO facade will generate all then.
+Publish `laraveltoolkit-config` to define site-wide metadata, social images, robots rules, and propagation. Page-level
+facade calls override those defaults for the current request.
 
-You can configura using the follow facade methods:
+---
 
-```php
-use Laraveltoolkit\Facades\SEO;
-// Disallow some path
-SEO::withRobotsTxtRule('user_agent_name', null, collect(['disallow_this_path', 'this_other_too']));
-
-// Allow some path
-SEO::withRobotsTxtRule('*', collect(['allow_this_path', 'this_other_too']));
-
-// Remove one user agent
-SEO::withoutRobotsTxtRule('google_bot');
-
-// Remove all users agent
-SEO::withoutRobotsTxtRule();
-
-// Passing sitemap url
-SEO::withRobotsTxtSitemap('https://fooobar.com/custom-sitemap.txt');
-
-// Removing sitemap url
-SEO::withoutRobotsTxtSitemap();
-```
-
-> If you not pass sitemap url, will be used de default sitemap route (`lt.sitemap`)
+[Back to the documentation index](README.md)

--- a/docs/SITEMAP.md
+++ b/docs/SITEMAP.md
@@ -1,48 +1,139 @@
-### Sitemap
+# Sitemap
 
-Provide a way to inform for Search engines the pages of your site.
+The Sitemap module renders cached XML sitemaps from URLs, collections, and chunked Eloquent queries. It also supports
+domain-specific definitions and sitemap indexes for large sites.
 
-Publish sitemap files using:
+## Setup
+
+Publish the editable sitemap registration file:
 
 ```bash
 php artisan vendor:publish --tag=laraveltoolkit-sitemap
 ```
 
-in routes/sitemap.php (after publishes it):
+When `sitemap.default_routes` is enabled, the package serves:
+
+- `/sitemap.xml` as `lt.sitemap`;
+- `/sitemap-{index}.xml` as `lt.sitemap_group`;
+- `/robots.txt` using the [SEO module](SEO.md).
+
+The sitemap endpoints return `404` until `routes/sitemap.php` exists.
+
+## Add URLs
+
+Register entries in `routes/sitemap.php`:
 
 ```php
-use App\Models\User;
 use Laraveltoolkit\Facades\Sitemap;
+use Laraveltoolkit\Sitemap\ChangeFrequency;
 
-// You can pass only url
-Sitemap::addUrl(route('index'));
-// Or a complete info (url, last modified, change frequency and priority
-Sitemap::addUrl(route('login'), today()->subDay(), ChangeFrequency::DAILY, 0.5);
+Sitemap::addUrl(route('home'));
 
-// You can interact with queries or collections
-Sitemap::fromQuery(User::query(), function (User $user) {
-    Sitemap::addUrl(route('index.user', $user->id), $user->created_at);
-});
-Sitemap::fromCollection(collect([10, 53, 29]), function (User $user) {
-    Sitemap::addUrl(route('index.user', $user->id));
-});
-
-// A group of sitemaps that only will return if domain matches. Other registries out from this group will be ignored
-Sitemap::domain('abc.dev.test', function () {
-    Sitemap::addUrl(route('login'));
-});
-
-// An index group used for huge sitemaps with more than 50k rows or 50MB
-Sitemap::index('users', function () {
- 
-    Sitemap::fromQuery(User::query(), function (User $user) {
-        Sitemap::addUrl(route('index.user', $user->id), $user->created_at);
-    });
-});
-// will be accessible on `route('lt.sitemap_group', "users");`
-
-// then to put this index on main sitemap use:
-Sitemap::addIndex('users');
+Sitemap::addUrl(
+    url: route('products.index'),
+    lastModified: today()->subDay(),
+    changeFrequency: ChangeFrequency::DAILY,
+    priority: 0.8,
+);
 ```
 
-> For mor info about sitemap in robots.txt go to [SEO docs](SEO.md)
+`lastModified`, `changeFrequency`, and `priority` are optional. Duplicate locations are included only once.
+
+## Collections and queries
+
+```php
+use App\Models\Product;
+
+Sitemap::fromCollection(['about', 'contact'], function (string $page) {
+    Sitemap::addUrl(route("pages.$page"));
+});
+
+Sitemap::fromQuery(
+    Product::query()->where('published', true),
+    function (Product $product) {
+        Sitemap::addUrl(
+            route('products.show', $product),
+            $product->updated_at,
+            ChangeFrequency::WEEKLY,
+        );
+    },
+    count: 500,
+);
+```
+
+Queries are processed with Eloquent's chunked `each()` operation unless the query already has a limit. The `count`
+argument controls chunk size and defaults to 1,000.
+
+## Multiple domains
+
+Wrap entries that should replace the default sitemap for one request hostname:
+
+```php
+Sitemap::domain('store.example.com', function () {
+    Sitemap::addUrl('https://store.example.com');
+    Sitemap::addUrl('https://store.example.com/products');
+});
+```
+
+When a matching domain is registered, only entries inside its callback are rendered for that hostname. Domain names
+must exactly match Laravel's `$request->getHost()` value, without scheme or path. Domains cannot be nested.
+
+## Sitemap indexes
+
+A sitemap cannot mix URL entries with index entries. For sites approaching search-engine limits, declare URL groups
+at the root of `routes/sitemap.php`, then make the main sitemap an index:
+
+```php
+Sitemap::index('products', function () {
+    Sitemap::fromQuery(Product::query(), function (Product $product) {
+        Sitemap::addUrl(route('products.show', $product), $product->updated_at);
+    });
+});
+
+Sitemap::index('pages', function () {
+    Sitemap::addUrl(route('home'));
+    Sitemap::addUrl(route('about'));
+});
+
+Sitemap::addIndex('products');
+Sitemap::addIndex('pages');
+```
+
+The resulting locations are:
+
+```text
+/sitemap.xml
+/sitemap-products.xml
+/sitemap-pages.xml
+```
+
+Do not add normal URLs outside the index groups when the main sitemap contains `addIndex()` entries.
+
+## Configuration and caching
+
+Publish the package configuration to change sitemap behavior:
+
+```php
+'sitemap' => [
+    'cache' => 21_600,
+    'default_routes' => true,
+    'timeout' => null,
+    'max_file_items' => 50_000,
+    'max_file_size' => 50 * 1024 * 1024,
+],
+```
+
+- `cache` is the XML cache lifetime in seconds; set it to `false` to disable caching.
+- `timeout` optionally changes PHP's execution time while rendering.
+- `max_file_items` and `max_file_size` emit warnings when exceeded; they do not split the sitemap automatically.
+- `default_routes` disables all package sitemap and robots routes when `false`.
+
+The cache key includes the hostname, index name, and modification time of `routes/sitemap.php`. Database changes do
+not automatically invalidate cached XML, so clear the application cache or choose an appropriate TTL when sitemap
+content changes frequently.
+
+Every sitemap response dispatches `Laraveltoolkit\Sitemap\SitemapRequestedEvent` after rendering.
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/STORED_ASSETS.md
+++ b/docs/STORED_ASSETS.md
@@ -1,90 +1,209 @@
-### Stored Assets
+# Stored Assets
 
-After all you must configure the models that will use stored assets feature.
+Stored Assets ties durable files to Eloquent attributes through recipes. A recipe can store one source file as one or
+more named variants, choose disks and visibility, and return rich `Asset` objects from the model. A queued garbage
+collector moves unreferenced asset directories to a recoverable trash bin before permanent deletion.
 
-First publish migration:
+## Setup
+
+### 1. Publish migrations and configuration
 
 ```bash
 php artisan vendor:publish --tag=laraveltoolkit-migrations
-```
-
-and run it
-
-```bash
+php artisan vendor:publish --tag=laraveltoolkit-config
 php artisan migrate
 ```
 
-Then generate model/field store recipe:
-
-```bash
-php artisian make:store-recipe ProductImageRecipe
-```
-
-After configure it:
+The package migration creates `stored_assets`, which records each asset set. Your application model also needs a
+nullable UUID column for every stored-asset field:
 
 ```php
-/**
-     * @inheritDoc
-     */
-    protected function prepareForSave(AssetIntent $baseAsset): AssetIntent|Collection
-    {
-//        return collect([
-//            $baseAsset->withDisk('local')->withKey('default')->withFilenameStoreType(FilenameStoreType::KEY),
-//            AssetIntent::create($baseAsset->pathname)->withDisk('local')
-//                ->withFilenameStoreType(FilenameStoreType::KEY)
-//                ->withKey('thumbnail'),
-//        ]); or
-
-        return $baseAsset->withDisk('local')->withKey('default');
-    }
+Schema::table('products', function (Blueprint $table) {
+    $table->storedAsset('image')->nullable();
+});
 ```
 
-Here you can create thumbs, format file or images and more. You must return an `AssetIntent` or a collection of it.
+`storedAsset()` is a package schema macro equivalent to an indexed UUID column.
 
-On model add stored trait and put recipe to cast asset field:
+### 2. Generate a recipe
+
+```bash
+php artisan make:store-recipe ProductImageRecipe
+```
+
+Configure the generated recipe by returning one `AssetIntent`:
+
+```php
+namespace App\StoreRecipes;
+
+use Illuminate\Support\Collection;
+use Laraveltoolkit\StoredAssets\AssetIntent;
+use Laraveltoolkit\StoredAssets\FilenameStoreType;
+use Laraveltoolkit\StoredAssets\Recipe;
+
+final class ProductImageRecipe extends Recipe
+{
+    protected function prepareForSave(AssetIntent $baseAsset): AssetIntent|Collection
+    {
+        return $baseAsset
+            ->withDisk('public')
+            ->withKey('default')
+            ->withFilenameStoreType(FilenameStoreType::KEY)
+            ->asPublic();
+    }
+}
+```
+
+The source is available as `$baseAsset->pathname`, so the recipe is the right place to optimize an image, generate a
+thumbnail, convert a document, or inspect metadata before storage.
+
+### 3. Configure the model
+
+Add the trait and cast the UUID column to your recipe:
 
 ```php
 use App\StoreRecipes\ProductImageRecipe;
 use Illuminate\Database\Eloquent\Model;
 use Laraveltoolkit\StoredAssets\HasStoredAssets;
 
-class Product extends Model
+final class Product extends Model
 {
-    // Add trait
     use HasStoredAssets;
 
-    //..
-
-/**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
     protected function casts(): array
     {
         return [
-            //...
             'image' => ProductImageRecipe::class,
-            //...
         ];
     }
 }
 ```
 
-That is all. Now you can save an asset just passing an UploadedFile, a File, or a path.
+The recipe cast and database column must use the same field name.
 
-For handling with model rows, you must configure a job that will move files for trash and some days after delete it:
+## Store and read an asset
+
+Assign an uploaded file, an `Illuminate\Http\File`, a local pathname, an existing stored-asset UUID, or `null`:
 
 ```php
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Facades\Artisan;
+$product->image = $request->file('image');
+$product->save();
+
+$product->image_uuid;          // UUID stored in products.image
+$product->image->default;      // Laraveltoolkit\StoredAssets\Asset
+$product->image->default->url();
+$product->image->default->get();
+$product->image->default->readStream();
+$product->image->default->temporaryUrl(now()->addMinutes(10));
+```
+
+File recipes run during the model's `saving` event. Saving creates the physical assets and a `stored_assets` record,
+then writes its UUID to the model column.
+
+When reusing an existing UUID, the referenced stored-asset record must exist. The package rejects arbitrary or stale
+UUIDs.
+
+## Multiple variants
+
+Return a collection of intents with unique keys:
+
+```php
+protected function prepareForSave(AssetIntent $baseAsset): AssetIntent|Collection
+{
+    $thumbnailPath = $this->createThumbnail($baseAsset->pathname);
+
+    return collect([
+        $baseAsset
+            ->withDisk('public')
+            ->withKey('original')
+            ->withFilenameStoreType(FilenameStoreType::KEY)
+            ->asPublic(),
+
+        AssetIntent::create($thumbnailPath)
+            ->withDisk('public')
+            ->withKey('thumbnail')
+            ->withFilenameStoreType(FilenameStoreType::KEY)
+            ->asPublic(),
+    ]);
+}
+```
+
+Read variants by key:
+
+```php
+$product->image->original->url();
+$product->image->thumbnail->url();
+```
+
+Keys must be valid PHP-like identifiers and unique within a recipe result. `FilenameStoreType::KEY` uses the key as
+the filename; `FilenameStoreType::UUID` generates a UUID filename.
+
+## Creating intents
+
+Recipes usually receive the base intent, but custom variants can be created from other sources:
+
+```php
+AssetIntent::create($pathname);
+AssetIntent::createFromUploadedFile($uploadedFile);
+AssetIntent::createFromContent($generatedContents);
+AssetIntent::createFromResource($stream);
+```
+
+Intent options are chainable:
+
+```php
+$intent
+    ->withDisk('s3')
+    ->withKey('download')
+    ->withFilenameStoreType(FilenameStoreType::UUID)
+    ->withOptions(['CacheControl' => 'max-age=31536000'])
+    ->asPrivate();
+```
+
+`asPublic()` adds public visibility to the filesystem write; private is the default.
+
+## Garbage collection
+
+Deleting a model or replacing an asset does not synchronously delete files. Schedule the manager and run a queue
+worker:
+
+```php
+use Illuminate\Support\Facades\Schedule;
 use Laraveltoolkit\StoredAssets\Jobs\GarbageCollectorManager;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote')->hourly();
-
-
-Schedule::job(GarbageCollectorManager::class)
-    ->everySixHours();
+Schedule::job(new GarbageCollectorManager)
+    ->everySixHours()
+    ->withoutOverlapping();
 ```
+
+The manager:
+
+1. scans configured asset directories for UUIDs no longer referenced by their model field;
+2. moves orphaned directories to the trash bin;
+3. permanently removes trash entries after the configured deadline;
+4. dispatches a summary job.
+
+Pass disk names when assets are spread across multiple disks:
+
+```php
+new GarbageCollectorManager(['local', 'public', 's3']);
+```
+
+Relevant configuration:
+
+| Key | Purpose |
+|---|---|
+| `stored_assets.disk` | Default filesystem disk. |
+| `stored_assets.model` | Replaceable stored-asset Eloquent model. |
+| `stored_assets.path` | Base directory for assets. |
+| `stored_assets.filename_store_type` | Default `KEY` or `UUID` filename strategy. |
+| `stored_assets.trash_bin.folder` | Trash directory inside the base path. |
+| `stored_assets.trash_bin.deadline` | Minutes an orphan remains recoverable before deletion. |
+| `stored_assets.trash_bin_cleaner_timeout` | Seconds a cleanup job may work before continuing in a new job. |
+
+> [!IMPORTANT]
+> Keep queue workers running and schedule the manager. Without both, orphaned assets remain on disk indefinitely.
+
+---
+
+[Back to the documentation index](README.md)

--- a/docs/UTILITIES.md
+++ b/docs/UTILITIES.md
@@ -1,0 +1,265 @@
+# Utilities
+
+Laravel Toolkit registers a set of validation rules, Brazilian document and phone helpers, collection/string/number
+macros, enum serializers, regex helpers, and fluent value objects. They are available after Laravel discovers the
+package service provider.
+
+## Validation rules
+
+### CPF and CNPJ
+
+`DocumentRule` accepts formatted or unformatted values and validates their check digits:
+
+```php
+use Laraveltoolkit\Rules\DocumentRule;
+
+$validated = $request->validate([
+    'cpf' => ['required', DocumentRule::cpf()],
+    'cnpj' => ['required', DocumentRule::cnpj()],
+    'cpf_or_cnpj' => ['nullable', DocumentRule::both()],
+]);
+```
+
+Values must be strings. Add Laravel's `nullable` rule when the field may be absent.
+
+### Brazilian phone numbers
+
+`PhoneRule` can accept every supported format, one specific category, or a selected set:
+
+```php
+use Laraveltoolkit\Enum\Phone;
+use Laraveltoolkit\Rules\PhoneRule;
+
+$request->validate([
+    'phone' => ['required', PhoneRule::all()],
+    'mobile' => ['required', PhoneRule::mobile()],
+    'contact' => [
+        'required',
+        PhoneRule::make(Phone::LANDLINE, Phone::MOBILE),
+    ],
+]);
+```
+
+Available categories are `GENERIC`, `LANDLINE`, `LOCAL_FARE`, `MOBILE`, `NON_REGIONAL`, and `PUBLIC_SERVICES`.
+
+## Document and phone helpers
+
+The `Document` and `Phone` enums expose validation, masking, type detection, labels, and fake values:
+
+```php
+use Laraveltoolkit\Enum\Document;
+use Laraveltoolkit\Enum\Phone;
+
+Document::guessType('123.456.789-00'); // Document::CPF
+Document::CPF->mask('12345678900');    // 123.456.789-00
+Document::CPF->unmask('123.456.789-00');
+Document::CPF->validate('123.456.789-00');
+Document::CPF->checkDigits('123456789');
+Document::CPF->fake();
+
+Phone::guessType('(43) 99999-9999'); // Phone::MOBILE
+Phone::MOBILE->mask('43999999999');
+Phone::MOBILE->unmask('(43) 99999-9999');
+Phone::MOBILE->validate('(43) 99999-9999');
+Phone::MOBILE->fake();
+```
+
+Fake values are intended for factories and tests, not for identity verification.
+
+## String macros
+
+### Masks
+
+`Str::applyMask()` and its fluent equivalent consume input characters that match each placeholder:
+
+| Placeholder | Accepts |
+|:---:|---|
+| `0` | Digit |
+| `A` | Letter or digit |
+| `S` | Letter |
+
+Escape a literal placeholder with `\` in the mask.
+
+```php
+use Illuminate\Support\Str;
+
+Str::applyMask('12345678901', '000.000.000-00');
+// 123.456.789-01
+
+str('ABC1234')->applyMask('SSS-0000')->toString();
+// ABC-1234
+```
+
+### Personal names
+
+`personalName()` normalizes capitalization while keeping common Portuguese connectors lowercase:
+
+```php
+Str::personalName('ALLAN MARIUCCI DE CARVALHO');
+// Allan Mariucci de Carvalho
+
+str('luiz ap. de carvalho')->personalName()->toString();
+// Luiz Ap. de Carvalho
+```
+
+## Collection macros
+
+Use the locale-aware sort helpers when accented strings should follow the application's locale:
+
+```php
+collect(['João', 'Allan', 'Álan'])->collatorSort()->values();
+collect($users)->localeSortBy('name');
+collect($users)->localeSortByDesc('name');
+```
+
+`collatorSort()` accepts PHP sort flags, a direction, and an optional locale:
+
+```php
+collect(['item 10', 'item 2'])->collatorSort(
+    options: SORT_NATURAL,
+    direction: SORT_ASC,
+    locale: 'pt_BR',
+)->values();
+// ['item 2', 'item 10']
+```
+
+Convert keyed arrays or object collections to frontend-friendly option lists:
+
+```php
+collect(['draft' => 'Draft', 'published' => 'Published'])
+    ->toValueLabelFromArray();
+// [['value' => 'draft', 'label' => 'Draft'], ...]
+
+$users->toValueLabelFromObject(
+    label: 'name',
+    value: 'id',
+    keysToPreserve: ['avatar_url'],
+);
+```
+
+## Number macros
+
+```php
+use Illuminate\Support\Number;
+
+Number::spellCurrency(42.50, in: 'BRL', locale: 'pt_BR');
+
+Number::roundAsMultipleOf(
+    value: 1.025,
+    step: 0.01,
+    roundMode: \RoundingMode::HalfAwayFromZero,
+)->value; // "1.03"
+```
+
+`roundAsMultipleOf()` returns a `BcMath\Number` and supports optional `min` and `max` boundaries.
+
+## Enum helpers
+
+Add `HasArrayableEnum` and implement `ArrayableEnum` on a backed enum to expose value/label payloads:
+
+```php
+use Laraveltoolkit\Enum\ArrayableEnum;
+use Laraveltoolkit\Enum\HasArrayableEnum;
+
+enum Status: string implements ArrayableEnum
+{
+    use HasArrayableEnum;
+
+    case DRAFT = 'draft';
+    case PUBLISHED = 'published';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DRAFT => 'Draft',
+            self::PUBLISHED => 'Published',
+        };
+    }
+}
+
+Status::toEnumArray();
+// ['draft' => 'Draft', 'published' => 'Published']
+
+Status::toValueLabel(only: ['published']);
+// collect([['value' => 'published', 'label' => 'Published']])
+```
+
+Pass a sort flag and direction to sort by label. Leave `sortFlags` as `null` to preserve declaration order. The
+`only` and `except` arguments filter by backed enum value.
+
+## Regex facade
+
+```php
+use Laraveltoolkit\Facades\Regex;
+
+Regex::getHashtags('Ship it #laravel #php');
+Regex::isEmail('dev@example.com');
+Regex::isHexColor('#334155');
+Regex::isIPv4Address('127.0.0.1');
+Regex::isIPv6Address('::1');
+Regex::isIPAddress('::1');
+Regex::isURL('https://example.com/docs');
+Regex::isLikePhpVariableChars('valid_name');
+Regex::isSequenceOfUniqueChar('aaaa');
+
+Regex::onlyAlpha('Olá 123');                           // Olá
+Regex::onlyAlphaNumeric('Item 42!', allowSpace: true); // Item 42
+Regex::onlyNumeric('(43) 99999-9999');                // 43999999999
+```
+
+These are deliberately small format helpers. For security-sensitive email, URL, or IP validation, prefer PHP's
+specialized filters and validation rules appropriate to your threat model.
+
+## Schema and routing macros
+
+```php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('products', function (Blueprint $table) {
+    $table->measurement('weight'); // JSON column
+    $table->storedAsset('image');   // indexed UUID column
+});
+
+Route::getAndPost('/users', UsersController::class);
+// Registers HEAD, GET, and POST for the same action.
+```
+
+The Eloquent Builder `primevueData()` macro is covered in the [PrimeVue Data guide](PRIMEVUE_DATA.md). Request
+FilePond macros are covered in the [FilePond guide](FILEPOND.md).
+
+## Extended fluent values
+
+`ExtendedFluent` adds Eloquent-style `Attribute` accessors and mutators to Laravel's `Fluent`, including recursive
+normalization for API output and storage. `AsExtendedFluent` casts a JSON model attribute to your fluent class.
+
+```php
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Laraveltoolkit\Support\AsExtendedFluent;
+use Laraveltoolkit\Support\ExtendedFluent;
+
+final class Preferences extends ExtendedFluent
+{
+    protected function displayName(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => trim("{$this->first_name} {$this->last_name}"),
+        );
+    }
+}
+
+protected function casts(): array
+{
+    return [
+        'preferences' => AsExtendedFluent::of(Preferences::class),
+    ];
+}
+```
+
+Use `toArray()` for presentation and `toStorageArray()` or `toStorageJson()` when backed enums must be reduced to
+their scalar values.
+
+---
+
+[Back to the documentation index](README.md)


### PR DESCRIPTION
## Summary

- reorganize the main README around installation, quick starts, and feature groups
- rewrite the ACL, deploy, FilePond, Flash, PrimeVue Data, SEO, Sitemap, Stored Assets, and multi-domain guides
- add a documentation index, utilities reference, and contribution guide
- fix broken links, placeholder content, invalid examples, and missing operational/security notes

## Validation

- 532 tests passed with 2,150 assertions
- all 14 Markdown files rendered successfully
- local documentation links and whitespace checks passed