### PR TITLE
Fix flaky stored assets job test

### DIFF
--- a/tests/StoredAssets/JobsTest.php
+++ b/tests/StoredAssets/JobsTest.php
@@ -96,11 +96,12 @@ it('can run all jobs', function () {
     expect($disk->exists($assetPath))->toBeFalse()
         ->and($disk->exists($assetSubDir1))->toBeFalse()
         ->and($disk->exists($assetSubDir2))->toBeTrue();
+    $assetSubDir2HasOtherSubDirectories = $disk->directories($assetSubDir2) !== [];
     GarbageCollectorManager::dispatch();
 
     expect($disk->exists($assetPath))->toBeFalse()
         ->and($disk->exists($assetSubDir1))->toBeFalse()
-        ->and($disk->exists($assetSubDir2))->toBeFalse();
+        ->and($disk->exists($assetSubDir2))->toBe($assetSubDir2HasOtherSubDirectories);
 });
 
 it('can break after long garbage run', function () {


### PR DESCRIPTION
## Summary
- account for valid assets sharing the same parent directory
- keep asserting that empty parent directories are removed
- prevent UUID suffix collisions from making the job test flaky

## Validation
- 200 repeated runs of the flaky test
- vendor/bin/pest tests/StoredAssets
- vendor/bin/pint tests/StoredAssets/JobsTest.php --test