### PR TITLE
Add measurement value conversion helpers

### DIFF
--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -200,7 +200,15 @@ $length->sub(25)->value();               // -24.0; scalar values use the current
 $length->mul(2)->value();                // 2.0
 $length->div(4)->value();                // 0.25
 $length->to(LengthUnit::CENTIMETER)->value(); // 100.0
+$length->toFloat();                      // 1.0
+$length->toInteger();                    // 1
+$length->round(2);                       // 1.0
 ```
+
+`toFloat()` returns the displayed value explicitly as a `float`. `toInteger()` rounds the displayed value to an
+integer using `RoundingMode::HalfAwayFromZero` by default and throws an `OverflowException` when the result is outside
+PHP's native integer range. `round()` returns the displayed value as a `float` rounded to the requested precision.
+Both rounding methods accept a different `RoundingMode` as their last argument.
 
 Use `referenceValue()` to inspect the dimension's canonical value. It returns an `int` for an integral value within
 PHP's native integer range, an exact decimal `string` for a larger integer, and a `float` for a fractional value.
@@ -221,11 +229,15 @@ $length->format(precision: 2);                  // 1.234,50 pol (pt_BR)
 $length->format(locale: 'en');                  // 1,234.5 in
 $length->format(null, null, false, 'en');       // 1,234.5 inches
 $length->format(locale: 'pt_BR', short: false); // 1.234,5 polegadas
+$length->formatWithoutUnit();                   // 1.234,5
+$length->formatWithoutUnit(locale: 'en');       // 1,234.5
 ```
 
 When `locale` is omitted, the current Laravel application locale formats both the number and its postfix.
 Abbreviated postfixes are never pluralized. Complete postfixes use the number after display precision is applied, so
 `length(1.4, 'm')->format(precision: 0, short: false)` returns `1 metro`.
+Use `formatWithoutUnit()` to apply the same localized precision rules without appending either the abbreviated or
+complete unit.
 
 ## Eloquent casting
 

--- a/src/Measurement/Models/Number.php
+++ b/src/Measurement/Models/Number.php
@@ -56,6 +56,30 @@ abstract class Number implements Arrayable, Castable, JsonSerializable
         return (float) (string) $this->decimalValue();
     }
 
+    public function toInteger(
+        RoundingMode $roundingMode = RoundingMode::HalfAwayFromZero,
+    ): int {
+        $value = $this->decimalValue()->round(0, $roundingMode);
+
+        if ($value->compare(PHP_INT_MIN) < 0 || $value->compare(PHP_INT_MAX) > 0) {
+            throw new OverflowException('The rounded measurement value exceeds the native integer range.');
+        }
+
+        return (int) (string) $value;
+    }
+
+    public function toFloat(): float
+    {
+        return $this->value();
+    }
+
+    public function round(
+        int $precision = 0,
+        RoundingMode $roundingMode = RoundingMode::HalfAwayFromZero,
+    ): float {
+        return (float) (string) $this->decimalValue()->round($precision, $roundingMode);
+    }
+
     public function referenceValue(): int|float|string
     {
         $value = $this->referenceValueString();
@@ -86,14 +110,9 @@ abstract class Number implements Arrayable, Castable, JsonSerializable
         ?string $locale = null,
     ): string|false {
         $locale ??= app()->getLocale();
-        $value = LaravelNumber::format(
-            $this->value(),
-            $precision,
-            $maxPrecision,
-            $locale,
-        );
+        $value = $this->formatWithoutUnit($precision, $maxPrecision, $locale);
 
-        // NumberFormatter only returns false for unsupported input types.
+        // formatWithoutUnit() only returns false for unsupported input types.
         // @codeCoverageIgnoreStart
         if ($value === false) {
             return false;
@@ -109,6 +128,29 @@ abstract class Number implements Arrayable, Castable, JsonSerializable
         $postfix = $this->unit()->formattedName($displayValue, $locale);
 
         return "{$value} {$postfix}";
+    }
+
+    public function formatWithoutUnit(
+        ?int $precision = null,
+        ?int $maxPrecision = null,
+        ?string $locale = null,
+    ): string|false {
+        $locale ??= app()->getLocale();
+        $value = LaravelNumber::format(
+            $this->value(),
+            $precision,
+            $maxPrecision,
+            $locale,
+        );
+
+        // NumberFormatter only returns false for unsupported input types.
+        // @codeCoverageIgnoreStart
+        if ($value === false) {
+            return false;
+        }
+        // @codeCoverageIgnoreEnd
+
+        return $value;
     }
 
     public function add(

--- a/tests/Measurement/LengthTest.php
+++ b/tests/Measurement/LengthTest.php
@@ -47,7 +47,24 @@ it('formats a length using the maximum precision behavior from Laravel', functio
     $length = length(1234.567, LengthUnit::CENTIMETER);
 
     expect($length->format(maxPrecision: 2))->toBe('1.234,57 cm')
-        ->and($length->format(precision: 4, maxPrecision: 2))->toBe('1.234,57 cm');
+        ->and($length->format(precision: 4, maxPrecision: 2))->toBe('1.234,57 cm')
+        ->and($length->formatWithoutUnit(maxPrecision: 2))->toBe('1.234,57')
+        ->and($length->formatWithoutUnit(precision: 2, locale: 'en'))->toBe('1,234.57');
+});
+
+it('returns explicitly typed and rounded display values', function () {
+    $length = length(12.55, LengthUnit::CENTIMETER);
+
+    expect($length->toFloat())->toBe(12.55)
+        ->and($length->toInteger())->toBe(13)
+        ->and($length->toInteger(RoundingMode::TowardsZero))->toBe(12)
+        ->and($length->round())->toBe(13.0)
+        ->and($length->round(1, RoundingMode::HalfEven))->toBe(12.6)
+        ->and(length(PHP_INT_MAX, 'm')->toInteger())->toBe(PHP_INT_MAX)
+        ->and(fn () => length(PHP_INT_MAX, 'm')->add(1)->toInteger())
+        ->toThrow(OverflowException::class, 'exceeds the native integer range')
+        ->and(fn () => length(PHP_INT_MIN, 'm')->sub(1)->toInteger())
+        ->toThrow(OverflowException::class, 'exceeds the native integer range');
 });
 
 it('resolves units from names, values, and terms', function () {


### PR DESCRIPTION
## Summary

- add toInteger(), toFloat(), and round() scalar accessors to measurement numbers
- add formatWithoutUnit() for localized numeric formatting without a unit suffix
- guard integer conversion against native range overflow
- document the new API and cover rounding, formatting, and overflow behavior

## Validation

- vendor/bin/pint src/Measurement/Models/Number.php tests/Measurement/LengthTest.php
- vendor/bin/pest --parallel (533 tests, 2162 assertions)
- composer validate --strict --no-check-publish
- git diff --check

## Environment limitations

- PHPStan was unavailable because vendor/bin/phpstan is not installed
- exact coverage could not run because no coverage driver is available