### PR TITLE
Add measurement comparison helpers

### DIFF
--- a/docs/MEASUREMENT.md
+++ b/docs/MEASUREMENT.md
@@ -203,12 +203,22 @@ $length->to(LengthUnit::CENTIMETER)->value(); // 100.0
 $length->toFloat();                      // 1.0
 $length->toInteger();                    // 1
 $length->round(2);                       // 1.0
+$length->gt(length(99, 'cm'));           // true; measurement units are normalized
+$length->gte(1);                         // true; scalars use the current unit (meters)
+$length->lt(1.01);                       // true
+$length->lte(length(100, 'cm'));         // true
 ```
 
 `toFloat()` returns the displayed value explicitly as a `float`. `toInteger()` rounds the displayed value to an
 integer using `RoundingMode::HalfAwayFromZero` by default and throws an `OverflowException` when the result is outside
 PHP's native integer range. `round()` returns the displayed value as a `float` rounded to the requested precision.
 Both rounding methods accept a different `RoundingMode` as their last argument.
+
+`compare()`, `equals()`, `gt()`, `gte()`, `lt()`, and `lte()` accept another compatible measurement or an `int` or
+`float`. Measurements are compared through their canonical reference unit, while scalar values are interpreted as
+absolute values in the receiving object's current unit. Incompatible measurement dimensions throw an
+`InvalidArgumentException`. This distinction is especially important for temperatures, where a scalar is an absolute
+value rather than a temperature delta.
 
 Use `referenceValue()` to inspect the dimension's canonical value. It returns an `int` for an integral value within
 PHP's native integer range, an exact decimal `string` for a larger integer, and a `float` for a fractional value.

--- a/src/Measurement/Models/Number.php
+++ b/src/Measurement/Models/Number.php
@@ -219,16 +219,34 @@ abstract class Number implements Arrayable, Castable, JsonSerializable
         return $this->newInstance($this->referenceValue, $unit);
     }
 
-    public function compare(Number $number): int
+    public function compare(Number|int|float $value): int
     {
-        $this->assertCompatible($number->unit());
-
-        return $this->referenceValue->compare($number->referenceValue);
+        return $this->referenceValue->compare($this->comparisonReferenceValue($value));
     }
 
-    public function equals(Number $number): bool
+    public function equals(Number|int|float $value): bool
     {
-        return $this->compare($number) === 0;
+        return $this->compare($value) === 0;
+    }
+
+    public function gt(Number|int|float $value): bool
+    {
+        return $this->compare($value) > 0;
+    }
+
+    public function gte(Number|int|float $value): bool
+    {
+        return $this->compare($value) >= 0;
+    }
+
+    public function lt(Number|int|float $value): bool
+    {
+        return $this->compare($value) < 0;
+    }
+
+    public function lte(Number|int|float $value): bool
+    {
+        return $this->compare($value) <= 0;
     }
 
     public function toArray(): array
@@ -317,6 +335,20 @@ abstract class Number implements Arrayable, Castable, JsonSerializable
         $this->assertCompatible($value->unit());
 
         return $value->referenceValue;
+    }
+
+    private function comparisonReferenceValue(Number|int|float $value): BcNumber
+    {
+        if ($value instanceof Number) {
+            $this->assertCompatible($value->unit());
+
+            return $value->referenceValue;
+        }
+
+        return self::roundReference(
+            $this->unit()->toReference(self::scalarToNumber($value)),
+            RoundingMode::HalfAwayFromZero,
+        );
     }
 
     private static function roundReference(BcNumber $value, RoundingMode $roundingMode): BcNumber

--- a/tests/Measurement/LengthTest.php
+++ b/tests/Measurement/LengthTest.php
@@ -112,10 +112,28 @@ it('performs immutable arithmetic in the current unit', function () {
         ->and($quotient->unit)->toBe(LengthUnit::METER);
 });
 
-it('compares equivalent lengths', function () {
+it('compares lengths using measurements and scalars in the current unit', function () {
     expect(length(1, 'm')->equals(length(100, 'cm')))->toBeTrue()
+        ->and(length(1, 'm')->equals(1))->toBeTrue()
         ->and(length(1, 'm')->compare(length(99, 'cm')))->toBe(1)
-        ->and(length(1, 'm')->compare(length(101, 'cm')))->toBe(-1);
+        ->and(length(1, 'm')->compare(1.5))->toBe(-1)
+        ->and(length(1, 'm')->gt(length(99, 'cm')))->toBeTrue()
+        ->and(length(1, 'm')->gt(0.99))->toBeTrue()
+        ->and(length(1, 'm')->gte(length(100, 'cm')))->toBeTrue()
+        ->and(length(1, 'm')->gte(1))->toBeTrue()
+        ->and(length(1, 'm')->lt(length(101, 'cm')))->toBeTrue()
+        ->and(length(1, 'm')->lt(1.01))->toBeTrue()
+        ->and(length(1, 'm')->lte(length(100, 'cm')))->toBeTrue()
+        ->and(length(1, 'm')->lte(1))->toBeTrue()
+        ->and(length(1, 'm')->gt(1))->toBeFalse()
+        ->and(length(1, 'm')->gte(1.01))->toBeFalse()
+        ->and(length(1, 'm')->lt(1))->toBeFalse()
+        ->and(length(1, 'm')->lte(0.99))->toBeFalse();
+});
+
+it('rejects comparisons between incompatible measurement types', function () {
+    expect(fn () => length(1, 'm')->gt(weight(1, 'kg')))
+        ->toThrow(InvalidArgumentException::class, 'Cannot operate on [length] and [weight] measurements.');
 });
 
 it('serializes a length without requiring a string representation', function () {

--- a/tests/Measurement/TemperatureTest.php
+++ b/tests/Measurement/TemperatureTest.php
@@ -26,6 +26,14 @@ it('converts absolute temperatures with their offsets', function () {
         ->and(temperature(0)->referenceValue())->toBe(2_458_350_000_000);
 });
 
+it('compares absolute temperatures across units and against current-unit scalars', function () {
+    expect(temperature(0, '°C')->gte(temperature(32, '°F')))->toBeTrue()
+        ->and(temperature(0, '°C')->lte(temperature(273.15, 'K')))->toBeTrue()
+        ->and(temperature(32, '°F')->equals(32))->toBeTrue()
+        ->and(temperature(32, '°F')->gt(31.9))->toBeTrue()
+        ->and(temperature(273.15, 'K')->lt(274))->toBeTrue();
+});
+
 it('applies scalar temperature deltas in the current scale', function () {
     expect(temperature(10, '°C')->add(5)->value())->toBe(15.0)
         ->and(temperature(50, '°F')->add(10)->value())->toBe(60.0)


### PR DESCRIPTION
## Summary
- add gt, gte, lt, and lte helpers accepting Number, int, or float
- extend compare and equals with the same operand types for a consistent API
- compare measurements through canonical units and treat scalars as absolute values in the current unit
- reject incompatible measurement dimensions and cover temperature offsets

## Tests
- composer test (535 passed, 2182 assertions)
- vendor/bin/pint --test
- composer analyse could not run because vendor/bin/phpstan is not installed by the current dependencies